### PR TITLE
Add promise tagline, meta info, and pricing anchor

### DIFF
--- a/about.html
+++ b/about.html
@@ -5,6 +5,10 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Lose fat, gain strength, stay pain-free—backed by elite-level lifting experience.">
+    <meta property="og:title" content="About | Matt McGinley Personal Training">
+    <meta property="og:description" content="Lose fat, gain strength, stay pain-free—backed by elite-level lifting experience.">
+    <meta property="og:image" content="PersonalTrainingAILogo.jpeg">
     <title>About</title>
     <link rel="stylesheet" href="css/style.css">
 </head>
@@ -21,6 +25,7 @@
     </nav>
     <header class="hero">
         <h1>About Me</h1>
+        <p class="tagline">Lose fat, gain strength, stay pain-free—backed by elite-level lifting experience.</p>
         <aside><a class="emailIG" href="mailto:matthewmcginley@live.com">matthewmcginley@live.com</a> | <a class="emailIG"
                 href="www.instagram.com/mattmcginley7"> Instagram</a></aside>
     </header>

--- a/begin.html
+++ b/begin.html
@@ -5,6 +5,10 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Lose fat, gain strength, stay pain-free—backed by elite-level lifting experience.">
+    <meta property="og:title" content="Getting Started | Matt McGinley Personal Training">
+    <meta property="og:description" content="Lose fat, gain strength, stay pain-free—backed by elite-level lifting experience.">
+    <meta property="og:image" content="PersonalTrainingAILogo.jpeg">
     <title>Getting Started</title>
     <link rel="stylesheet" href="css/style.css">
 </head>
@@ -22,6 +26,7 @@
 
     <header class="hero">
         <h1>Let's Start!!</h1>
+        <p class="tagline">Lose fat, gain strength, stay pain-free—backed by elite-level lifting experience.</p>
         <aside><a class="emailIG" href="mailto:matthewmcginley@live.com">matthewmcginley@live.com</a> |
             <a class="emailIG" href="www.instagram.com/mattmcginley7"> Instagram</a></aside>
     </header>

--- a/calculators.html
+++ b/calculators.html
@@ -5,6 +5,10 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Lose fat, gain strength, stay pain-free—backed by elite-level lifting experience.">
+    <meta property="og:title" content="Calculators | Matt McGinley Personal Training">
+    <meta property="og:description" content="Lose fat, gain strength, stay pain-free—backed by elite-level lifting experience.">
+    <meta property="og:image" content="PersonalTrainingAILogo.jpeg">
     <title>Calculators</title>
     <link rel="stylesheet" href="css/style.css">
 </head>
@@ -21,6 +25,7 @@
     </nav>
     <header class="hero">
         <h1>Calculators</h1>
+        <p class="tagline">Lose fat, gain strength, stay pain-free—backed by elite-level lifting experience.</p>
         <aside><a class="emailIG" href="mailto:matthewmcginley@live.com">matthewmcginley@live.com</a> |
             <a class="emailIG" href="www.instagram.com/mattmcginley7"> Instagram</a></aside>
     </header>

--- a/css/style.css
+++ b/css/style.css
@@ -46,6 +46,17 @@ section {
     padding: 2rem 0 1rem;
 }
 
+.tagline {
+    font-size: 1.25em;
+    margin: 0.5em 0;
+    text-align: center;
+}
+
+.pricing-anchor {
+    text-align: center;
+    font-size: 1.25em;
+}
+
 img {
     width: 100%;
     max-width: 400px;

--- a/index.html
+++ b/index.html
@@ -6,6 +6,10 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;700&display=swap" rel="stylesheet">
+    <meta name="description" content="Lose fat, gain strength, stay pain-free—backed by elite-level lifting experience.">
+    <meta property="og:title" content="Matt McGinley Personal Training">
+    <meta property="og:description" content="Lose fat, gain strength, stay pain-free—backed by elite-level lifting experience.">
+    <meta property="og:image" content="PersonalTrainingAILogo.jpeg">
     <title>Matt McGinley Personal Training</title>
     <link rel="stylesheet" href="css/style.css">
 </head>
@@ -22,6 +26,7 @@
     </nav>
     <header class="hero">
         <h1>Matt McGinley Personal Training</h1>
+        <p class="tagline">Lose fat, gain strength, stay pain-free—backed by elite-level lifting experience.</p>
         <aside><a class="emailIG" href="mailto:matthewmcginley@live.com">matthewmcginley@live.com</a> |
             <a class="emailIG" href="www.instagram.com/mattmcginley7"> Instagram</a></aside>
     </header>
@@ -32,7 +37,7 @@
         <h2>Why Online Training?</h2>
         <p>One of the biggest advantages to online personal training is convenience and affordability.
             With in person training, it's not always easy to set up and schedule and training sessions can be as much as $100 a session.
-            However, with online training, most trainers ask for $50 a week! That's $7 a day. However, my typical pricing is only $5 a day per month.
+            However, with online training, most trainers ask for $50 a week! That's $7 a day. <a href="services.html#pricing">Packages from $149/mo</a>.
         </p>
         <p>But overall, the greatest advantage that comes with a trainer is someone who really understands
             what it takes to get in shape, to build fat and lose muscle, has went through the same challenges

--- a/resources.html
+++ b/resources.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Lose fat, gain strength, stay pain-free—backed by elite-level lifting experience.">
+    <meta property="og:title" content="Tools | Matt McGinley Personal Training">
+    <meta property="og:description" content="Lose fat, gain strength, stay pain-free—backed by elite-level lifting experience.">
+    <meta property="og:image" content="PersonalTrainingAILogo.jpeg">
     <title>Tools</title>
     <link rel="stylesheet" href="css/style.css">
 </head>
@@ -19,6 +23,7 @@
     </nav>
     <header class="hero">
         <h1>Resources</h1>
+        <p class="tagline">Lose fat, gain strength, stay pain-free—backed by elite-level lifting experience.</p>
         <aside><a class="emailIG" href="mailto:matthewmcginley@live.com">matthewmcginley@live.com</a> |
             <a class="emailIG" href="www.instagram.com/mattmcginley7"> Instagram</a></aside>
     </header>

--- a/services.html
+++ b/services.html
@@ -5,6 +5,10 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Lose fat, gain strength, stay pain-free—backed by elite-level lifting experience.">
+    <meta property="og:title" content="Services | Matt McGinley Personal Training">
+    <meta property="og:description" content="Lose fat, gain strength, stay pain-free—backed by elite-level lifting experience.">
+    <meta property="og:image" content="PersonalTrainingAILogo.jpeg">
     <title>Services</title>
     <link rel="stylesheet" href="css/style.css">
 </head>
@@ -21,11 +25,13 @@
     </nav>
     <header class="hero">
         <h1>Services</h1>
+        <p class="tagline">Lose fat, gain strength, stay pain-free—backed by elite-level lifting experience.</p>
         <aside><a class="emailIG" href="mailto:matthewmcginley@live.com">matthewmcginley@live.com</a> |
             <a class="emailIG" href="www.instagram.com/mattmcginley7"> Instagram</a></aside>
     </header>
     <img id="mainImage"
         src="https://lh3.googleusercontent.com/gVYHlRHzgcxuZkFNOrDmsn26GoI4qBV-wKhk-bwwAm2WG3WLsc8YPzMWfY0LV34FZqmGnN2F8kJRGyahqX1N0Mc-8cNH_WDVOODUsmdaBM6CBohujeEMjHAGnstPW-dGWGx1xykRNw=w600-h315-p-k" />
+    <h3 id="pricing" class="pricing-anchor">Packages from $149/mo</h3>
     <section>
         <h2>Online Training: What's Included?</h2>
         <h4>Customized Workout Plans</h4> 


### PR DESCRIPTION
## Summary
- show core promise on every page
- add meta description and open graph tags across pages
- link to pricing info from the homepage
- highlight pricing packages on Services page
- style tagline and pricing anchor

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68509d2bd9dc8326bf987db02a21b23b