### PR TITLE
Replace email CTA with Calendly and intake form

### DIFF
--- a/begin.html
+++ b/begin.html
@@ -27,8 +27,9 @@
     <header class="hero">
         <h1>Let's Start!!</h1>
         <p class="tagline">Lose fat, gain muscle, live pain-free</p>
-        <aside><a class="emailIG" href="mailto:matthewmcginley@live.com">matthewmcginley@live.com</a> |
-            <a class="emailIG" href="https://www.instagram.com/mattmcginley7"> Instagram</a></aside>
+        <aside>
+            <a class="emailIG" href="https://www.instagram.com/mattmcginley7">Instagram</a>
+        </aside>
     </header>
     <section>
 <img src="MeFlexing4.jpg" alt="">
@@ -36,9 +37,21 @@
 <p id="startParagraph">You have nothing to lose and everything to gain by starting your fitness journey.
     You deserve to reach your health and fitness goals and be in the shape you want to be in.
     I will provide you with a personalized plan, motivation and a proven method that works for anyone, no matter your age, shape or
-level. Don't let fear or doubt stop you from taking action. Email me today with your name and your goals and let's do this!
+level. Don't let fear or doubt stop you from taking action. Schedule your first consultation below and tell me a bit about your goals!
 </p>
-<div><button><a href="mailto:matthewmcginley@live.com">Email me</a></button></div>
+
+<div class="calendly-inline-widget" data-url="https://calendly.com/example/consultation" style="min-width:320px;height:630px;"></div>
+<script type="text/javascript" src="https://assets.calendly.com/assets/external/widget.js" async></script>
+
+<form name="intake" method="POST" data-netlify="true">
+    <label for="name">Name:</label>
+    <input type="text" id="name" name="name" required>
+    <label for="email">Email:</label>
+    <input type="email" id="email" name="email" required>
+    <label for="goals">Goals:</label>
+    <textarea id="goals" name="goals" rows="4" required></textarea>
+    <button type="submit">Submit</button>
+</form>
 
     </section>
     <script type="text/javascript" src="js/main.js"></script>

--- a/css/style.css
+++ b/css/style.css
@@ -175,6 +175,13 @@ input{
     margin: 0.5em 0;
     margin: 0 18px 0 18px;
 }
+textarea{
+    margin: 0.5em 0;
+    margin: 0 18px 0 18px;
+}
+form{
+    text-align: center;
+}
 
 #edCoanPhaseParagraph {
     padding-top: 20px;


### PR DESCRIPTION
## Summary
- remove email contact link
- add Calendly scheduler and intake form on the Begin page
- style new form elements

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68534ce61b508326838a3c868a2493e0