### PR TITLE
Add Articles page with nav link

### DIFF
--- a/about.html
+++ b/about.html
@@ -19,6 +19,7 @@
             <li><a href="index.html">Home</a></li>
             <li><a href="services.html">Services</a></li>
             <li><a href="resources.html">Resources</a></li>
+            <li><a href="articles.html">Articles</a></li>
             <li><a href="calculators.html">Calculators</a></li>
             <li><a href="begin.html">Begin</a></li>
         </ul>

--- a/articles.html
+++ b/articles.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Lose fat, gain strength, stay pain-free—backed by elite-level lifting experience.">
+    <meta property="og:title" content="Articles | Matt McGinley Personal Training">
+    <meta property="og:description" content="Lose fat, gain strength, stay pain-free—backed by elite-level lifting experience.">
+    <meta property="og:image" content="PersonalTrainingAILogo.jpeg">
+    <title>Articles - Matt McGinley Personal Training</title>
+    <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+    <nav>
+        <ul>
+            <li><a href="index.html">Home</a></li>
+            <li><a href="about.html">About</a></li>
+            <li><a href="services.html">Services</a></li>
+            <li><a href="resources.html">Resources</a></li>
+            <li><a href="calculators.html">Calculators</a></li>
+            <li><a href="begin.html">Begin</a></li>
+        </ul>
+    </nav>
+    <header class="hero">
+        <h1>Articles</h1>
+        <p class="tagline">Thoughts on training and nutrition</p>
+        <aside><a class="emailIG" href="mailto:matthewmcginley@live.com">matthewmcginley@live.com</a> |
+            <a class="emailIG" href="https://www.instagram.com/mattmcginley7"> Instagram</a></aside>
+    </header>
+    <section>
+        <article>
+            <h2>Getting Started With Your Fitness Journey</h2>
+            <p>This mock post demonstrates where future articles will go. Here you can share insights,
+                tips, and stories to help visitors stay motivated on their path to better health.</p>
+        </article>
+    </section>
+    <script type="text/javascript" src="js/main.js"></script>
+</body>
+</html>

--- a/begin.html
+++ b/begin.html
@@ -20,6 +20,7 @@
             <li><a href="about.html">About</a></li>
             <li><a href="services.html">Services</a></li>
             <li><a href="resources.html">Resources</a></li>
+            <li><a href="articles.html">Articles</a></li>
             <li><a href="calculators.html">Calculators</a></li>
         </ul>
     </nav>

--- a/calculators.html
+++ b/calculators.html
@@ -20,6 +20,7 @@
             <li><a href="about.html">About</a></li>
             <li><a href="services.html">Services</a></li>
             <li><a href="resources.html">Resources</a></li>
+            <li><a href="articles.html">Articles</a></li>
             <li><a href="begin.html">Begin</a></li>
         </ul>
     </nav>

--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
             <li><a href="about.html">About</a></li>
             <li><a href="services.html">Services</a></li>
             <li><a href="resources.html">Resources</a></li>
+            <li><a href="articles.html">Articles</a></li>
             <li><a href="calculators.html">Calculators</a></li>
             <li><a href="begin.html">Begin</a></li>
         </ul>

--- a/resources.html
+++ b/resources.html
@@ -17,6 +17,7 @@
             <li><a href="index.html">Home</a></li>
             <li><a href="about.html">About</a></li>
             <li><a href="services.html">Services</a></li>
+            <li><a href="articles.html">Articles</a></li>
             <li><a href="calculators.html">Calculators</a></li>
             <li><a href="begin.html">Begin</a></li>
         </ul>

--- a/services.html
+++ b/services.html
@@ -19,6 +19,7 @@
             <li><a href="index.html">Home</a></li>
             <li><a href="about.html">About</a></li>
             <li><a href="resources.html">Resources</a></li>
+            <li><a href="articles.html">Articles</a></li>
             <li><a href="calculators.html">Calculators</a></li>
             <li><a href="begin.html">Begin</a></li>
         </ul>


### PR DESCRIPTION
## Summary
- create mock Articles page
- link to Articles from the site nav across pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68534f85334c8326b7b99ea9d287863b