### PR TITLE
Fix contact section on Begin page

### DIFF
--- a/begin.html
+++ b/begin.html
@@ -28,9 +28,7 @@
     <header class="hero">
         <h1>Let's Start!!</h1>
         <p class="tagline">Lose fat, gain muscle, live pain-free</p>
-        <aside>
-            <a class="emailIG" href="https://www.instagram.com/mattmcginley7">Instagram</a>
-        </aside>
+        <aside><a class="emailIG" href="mailto:matthewmcginley@live.com">matthewmcginley@live.com</a> | <a class="emailIG" href="https://www.instagram.com/mattmcginley7"> Instagram</a></aside>
     </header>
     <section>
 <img src="MeFlexing4.jpg" alt="">
@@ -38,13 +36,11 @@
 <p id="startParagraph">You have nothing to lose and everything to gain by starting your fitness journey.
     You deserve to reach your health and fitness goals and be in the shape you want to be in.
     I will provide you with a personalized plan, motivation and a proven method that works for anyone, no matter your age, shape or
-level. Don't let fear or doubt stop you from taking action. Schedule your first consultation below and tell me a bit about your goals!
+level. Don't let fear or doubt stop you from taking action. Email me at <a href="mailto:matthewmcginley@live.com">matthewmcginley@live.com</a> and tell me a bit about your goals!
 </p>
 
-<div class="calendly-inline-widget" data-url="https://calendly.com/example/consultation" style="min-width:320px;height:630px;"></div>
-<script type="text/javascript" src="https://assets.calendly.com/assets/external/widget.js" async></script>
 
-<form name="intake" method="POST" data-netlify="true">
+<form name="intake" action="mailto:matthewmcginley@live.com" method="POST" enctype="text/plain">
     <label for="name">Name:</label>
     <input type="text" id="name" name="name" required>
     <label for="email">Email:</label>


### PR DESCRIPTION
## Summary
- add email contact link to Begin page header
- update consultation instructions to email address
- remove broken Calendly widget and connect form to open an email

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685b427ade988326b6aeb64815ea36e9