### PR TITLE
Style calculators and add fonts

### DIFF
--- a/articles.html
+++ b/articles.html
@@ -10,7 +10,7 @@
     <meta property="og:image" content="PersonalTrainingAILogo.jpeg">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;700&family=Open+Sans:wght@300;400;700&display=swap" rel="stylesheet">
     <title>Articles - Matt McGinley Personal Training</title>
     <link rel="stylesheet" href="css/style.css">
 </head>

--- a/calculators.html
+++ b/calculators.html
@@ -30,7 +30,8 @@
         <aside><a class="emailIG" href="mailto:matthewmcginley@live.com">matthewmcginley@live.com</a> |
             <a class="emailIG" href="https://www.instagram.com/mattmcginley7"> Instagram</a></aside>
     </header>
-    <section>
+    <section class="calculator-section">
+    <div class="calculator-card smolov-calculator">
     <img src="MeFlexing1.jpg" alt="">
         <h3>Smolov Junior Calculator</h3>
         <p>Smolov Junior is a very popular squat program that can also be ran on the bench press. It is a lot of volume which can be hard to handle,
@@ -58,7 +59,9 @@
 
         
 
-        <h3>"The McGinley Method Bench Press Calculator"</h3>
+    </div>
+    <div class="calculator-card bench-calculator">
+    <h3>"The McGinley Method Bench Press Calculator"</h3>
         <p> This program is great for increasing your strength because it is forcing you to using heavy weights and yet
             it still does a great job of making sure you are able to recover workout to workout.
         </p>
@@ -91,7 +94,9 @@
             </div>
 
 
-            <h3>Ed Coan/Phillipi Deadlift Routine Calculator</h3>
+    </div>
+    <div class="calculator-card coan-calculator">
+    <h3>Ed Coan/Phillipi Deadlift Routine Calculator</h3>
             <p>This is my favorite deadlift program to run by far. Most of the program is centered around
                 progressively hitting around hitting a heavy double with more weight each week, followed by 
             backoff "speed" sets for 3 with a small rest time window. </p>
@@ -147,7 +152,9 @@
             <div id="deadTen">Deadlift: 1x1 105%</div>
             <div id="speedTen">Speed Deadlift: 2x3 60% (3 minutes rest between sets)</div>
 
-            <h3>Fat Free Mass Index Calculator</h3>
+    </div>
+    <div class="calculator-card ffmi-calculator">
+    <h3>Fat Free Mass Index Calculator</h3>
             <p>This tool estimates your fat free mass index (FFMI), a measure of muscularity adjusted for height. This is a great tool to use for those who lift weights to get a more accurate assessment of their body composition and what is possible.</p>
             <input id="ffmiWeight" type="text" placeholder="Weight (lbs)">
             <input id="ffmiBodyfat" type="text" placeholder="Body Fat %">
@@ -162,13 +169,16 @@
                 <li><strong>23+:</strong> Elite</li>
             </ul>
 
-            <h3>Body Mass Index Calculator</h3>
+    </div>
+    <div class="calculator-card bmi-calculator">
+    <h3>Body Mass Index Calculator</h3>
             <p>Use this calculator to estimate your BMI from your height and weight. This is useful for those who are not advanced weight lifters in general health and body composition.</p>
             <input id="bmiWeight" type="text" placeholder="Weight (lbs)">
             <input id="bmiHeight" type="text" placeholder="Height (in)">
             <button id="bmiButton" class="programButtons">Calculate</button>
             <div id="bmiResult"></div>
 
+    </div>
     </section>
     <script type="text/javascript" src="js/main.js"></script>
 </body>

--- a/css/style.css
+++ b/css/style.css
@@ -253,3 +253,23 @@ article ul {
 .article-section article:last-child {
     margin-bottom: 0;
 }
+
+/* Calculator card styling */
+.calculator-section {
+    padding: 0;
+    background: transparent;
+    box-shadow: none;
+}
+
+.calculator-card {
+    padding: 1rem 1.5rem;
+    background: #fff;
+    border-radius: 8px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+    margin-bottom: 2rem;
+    border: 1px solid #eee;
+}
+
+.calculator-card:last-child {
+    margin-bottom: 0;
+}


### PR DESCRIPTION
## Summary
- add Google Fonts to **articles** page
- use `.calculator-card` containers on calculators
- style calculator cards with padding, shadow and rounded corners

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686c484dd3b88326ba0e146479103a54