### PR TITLE
Update workout generator copy and remove mobile sticky submit bar

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1989,11 +1989,10 @@ article ul {
     }
 
     .workout-submit-wrap {
-        position: sticky;
-        bottom: 0.35rem;
-        background: linear-gradient(180deg, rgba(248, 250, 252, 0.35), rgba(248, 250, 252, 0.96));
-        padding: 0.8rem 0 0.2rem;
-        backdrop-filter: blur(4px);
+        position: static;
+        background: transparent;
+        padding: 0.9rem 0 0;
+        backdrop-filter: none;
     }
 
     .form-nav-buttons {

--- a/workout-generator.html
+++ b/workout-generator.html
@@ -29,7 +29,7 @@
         <div class="hero__content">
             <div class="hero__copy">
                 <p class="hero__eyebrow">Workout Generator</p>
-                <p class="workout-trust-pill">Built by a coach who programs real barbell training, not random circuit templates.</p>
+                <p class="workout-trust-pill">Built by me — these are my recommendations and exercise selections for your program.</p>
                 <h1>Get a serious 6-week program built for your goal, schedule, and lifting profile</h1>
                 <p class="tagline">In a few focused steps, generate a clean coaching-style plan with progression targets, exercise substitutions, and session-by-session execution notes.</p>
                 <ul class="hero-microproof">


### PR DESCRIPTION
### Motivation
- Clarify authorship and tone on the Workout Generator hero so messaging reads as first-person recommendations rather than third‑party coaching copy.
- Remove the mobile sticky submit/prompt so users complete the full form without a persistent bottom pop-up and press `Generate` on the final step.

### Description
- Replaced the hero trust-pill copy in `workout-generator.html` from “Built by a coach who programs real barbell training, not random circuit templates.” to “Built by me — these are my recommendations and exercise selections for your program.”.
- Removed the mobile sticky floating behavior by updating `.workout-submit-wrap` in `css/style.css` to `position: static`, cleared the background and `backdrop-filter`, and adjusted padding so the submit area flows inline on small screens.
- No JavaScript changes were required; the existing submit button visibility logic (`#submitPlanButton`) remains unchanged.

### Testing
- Ran `git diff --check` to validate the patch formatting and whitespace, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d81c308b288326b95d30831232198d)