### PR TITLE
Add “The Checklist for Why You’re Stuck” article to Articles page

### DIFF
--- a/articles.html
+++ b/articles.html
@@ -626,6 +626,108 @@
             <p>Bulking is not about eating everything in sight. It is about giving your body enough extra energy to build muscle, without overshooting into unnecessary fat gain.</p>
             <p>The lifters who build the best physiques over time are not the ones who bulk the hardest. They are the ones who bulk the smartest.</p>
         </article>
+        <article id="why-youre-stuck-checklist">
+            <h2>The Checklist for Why You’re Stuck</h2>
+            <p>If you feel like you’ve been working hard in the gym but your body, strength, or lifts are not changing much, there is usually a reason.</p>
+            <p>Most people who are stuck are not broken. They are usually just missing one or two big things.</p>
+            <p>Before you assume your genetics are terrible, your program is cursed, or you need some advanced method, run through this checklist.</p>
+
+            <h3>1. Are you progressively overloading?</h3>
+            <p>This is the first thing I would look at.</p>
+            <p>Are you actually giving your body a reason to improve?</p>
+            <p>That means over time, you should be trying to:</p>
+            <ul>
+                <li>Add a rep</li>
+                <li>Add a little weight</li>
+                <li>Improve your technique with the same weight</li>
+                <li>Make the same weight feel easier</li>
+            </ul>
+            <p>If week after week your workouts look exactly the same, your body has very little reason to adapt.</p>
+            <p>You do not need to set a personal record every workout. But there should be some kind of ongoing effort to move forward over time. Even adding one rep here or five pounds there matters.</p>
+            <p>If there is no plan to progress, that is a huge red flag.</p>
+
+            <h3>2. Are you training each muscle group often enough?</h3>
+            <p>A lot of people simply do not train each muscle group enough.</p>
+            <p>In most cases, training a muscle around 2 to 3 times per week works really well for building size and strength. If you only hit a muscle once per week, you can still make progress, but for many people it is slower and less reliable.</p>
+            <p>For most muscle groups, a good starting point is about 6 to 10 hard working sets per week, then adjusting based on recovery and progress.</p>
+            <p>That is enough for many people to grow without turning training into junk volume.</p>
+            <p>If you are not doing enough volume, progress can stall.</p>
+            <p>If you are doing way too much volume, that can also stall progress.</p>
+            <p>More is not always better. Better is better.</p>
+
+            <h3>3. Are your sets actually hard enough?</h3>
+            <p>A lot of people say they train hard, but they are not getting close enough to failure for the sets to really count.</p>
+            <p>You do not need to take every set to absolute failure, but most of your working sets should be close.</p>
+            <p>If you finish a set and could have done 5 more reps, that probably was not a very stimulative set.</p>
+            <p>A good rule is that many of your hard sets should end with maybe 0 to 3 reps left in the tank.</p>
+            <p>That is usually where the growth-producing reps live.</p>
+
+            <h3>4. Are you using rep ranges that are easy to progress?</h3>
+            <p>This is a big one that people do not think about enough.</p>
+            <p>Some rep ranges are just easier to progress than others.</p>
+            <p>For example, on a lift like the bench press, a lot of your training will usually work very well in roughly the 70% to 85% range of your one-rep max.</p>
+            <p>That often means sets like:</p>
+            <ul>
+                <li>5 sets of 5</li>
+                <li>4 sets of 6</li>
+                <li>3 to 5 sets of 4 to 8</li>
+            </ul>
+            <p>Why does this matter?</p>
+            <p>Because it is easier to build progress there.</p>
+            <p>It is much easier to add five pounds to a lift when you are doing something like 5x5 than when you are doing 5x10. High-rep work has a place, but if too much of your training lives in rep ranges that are hard to load progressively, strength progress can get messy.</p>
+            <p>If your whole program is built around fatigue instead of measurable progression, that could be part of why you are stuck.</p>
+
+            <h3>5. Are you eating in a way that supports muscle growth?</h3>
+            <p>Training is only part of the equation.</p>
+            <p>If your diet is poor, your results will usually reflect it.</p>
+            <p>Ask yourself:</p>
+            <ul>
+                <li>Are you eating enough protein?</li>
+                <li>Are you getting enough calories to recover?</li>
+                <li>Are you in a deep calorie deficit?</li>
+                <li>Are you consistently under-eating without realizing it?</li>
+                <li>Are you getting the nutrients your body needs?</li>
+            </ul>
+            <p>Protein matters because it helps maximize muscle protein synthesis and recovery.</p>
+            <p>Calories matter because if you are in too aggressive of a deficit, your body is not in a great position to build muscle or push strength upward.</p>
+            <p>A lot of people want to build muscle while eating like they are dieting for a photo shoot. That usually does not work very well.</p>
+
+            <h3>6. Are you recovering well enough to repeat good performances?</h3>
+            <p>You do not build muscle while lifting. You build it by recovering from lifting.</p>
+            <p>If your sleep is bad, your stress is high, your food is inconsistent, and your body is always run down, your workouts will suffer.</p>
+            <p>You do not need a perfect recovery routine, but you do need enough recovery to come back and perform well again.</p>
+            <p>If your performance is constantly flat or declining, recovery should be part of the checklist.</p>
+
+            <h3>The truth about being stuck</h3>
+            <p>Most plateaus are not mysterious.</p>
+            <p>Usually it comes down to one of a few things:</p>
+            <ul>
+                <li>No progressive overload</li>
+                <li>Bad training frequency</li>
+                <li>Too little or too much volume</li>
+                <li>Not training hard enough</li>
+                <li>Poor exercise loading or rep selection</li>
+                <li>Poor diet</li>
+                <li>Poor recovery</li>
+            </ul>
+            <p>That is good news, because it means the answer is usually fixable.</p>
+            <p>You probably do not need a brand new identity, a secret supplement, or some magical advanced program.</p>
+            <p>You just need to tighten up the basics.</p>
+
+            <h3>Run this checklist honestly</h3>
+            <p>If you are stuck, ask yourself:</p>
+            <ul>
+                <li>Am I progressively overloading?</li>
+                <li>Am I training each muscle group 2 to 3 times per week?</li>
+                <li>Am I doing about 6 to 10 hard working sets?</li>
+                <li>Am I training close enough to failure?</li>
+                <li>Am I using rep ranges and percentages that are easy to progress?</li>
+                <li>Am I eating enough protein and enough total food?</li>
+                <li>Am I recovering well enough to perform again?</li>
+            </ul>
+            <p>If you answer those honestly, the problem usually reveals itself pretty quickly.</p>
+            <p>And once you find the weak link, progress starts making sense again.</p>
+        </article>
     </section>
     <script type="text/javascript" src="js/main.js"></script>
 </body>

--- a/js/main.js
+++ b/js/main.js
@@ -308,7 +308,8 @@ document.addEventListener('DOMContentLoaded', function () {
         'not-gaining-muscle': { topic: 'Muscle building', date: '2026-02-24', startHere: false },
         'consistency-beats-motivation': { topic: 'Mindset', date: '2026-03-02', startHere: false },
         'cheat-code-losing-weight': { topic: 'Fat loss', date: '2026-03-09', startHere: false },
-        'correct-way-to-bulk': { topic: 'Nutrition', date: '2026-03-16', startHere: false }
+        'correct-way-to-bulk': { topic: 'Nutrition', date: '2026-03-16', startHere: false },
+        'why-youre-stuck-checklist': { topic: 'Programming', date: '2026-04-16', startHere: false }
     };
 
     var prettyDate = function (isoDate) {


### PR DESCRIPTION
### Motivation
- Convert a practical checklist about training plateaus into a polished article for the site so readers can self-diagnose why progress has stalled. 
- Make the guidance discoverable via the existing Articles page and its topic filters. 
- Keep content consistent with the site’s tone and article structure used elsewhere.

### Description
- Added a new article element to `articles.html` with `id="why-youre-stuck-checklist"` containing the full checklist content, section headings, and bullet lists. 
- Registered the article in the site discovery metadata by adding an entry to `articleMetaConfig` in `js/main.js` (`'why-youre-stuck-checklist': { topic: 'Programming', date: '2026-04-16', startHere: false }`). 
- Content was formatted to match existing article markup so it integrates with the article discovery, filtering, start-here grid, and navigation components.

### Testing
- Ran `node -c js/main.js` to validate the updated JavaScript file for syntax errors, and the check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1543583148326a6d3b2402917f2e8)