### PR TITLE
Fix homepage 'Why me' section contrast

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1518,6 +1518,10 @@ section,
     box-shadow: var(--shadow-deep);
 }
 
+.story-section {
+    background: linear-gradient(165deg, rgba(10, 30, 58, 0.95), rgba(7, 20, 40, 0.95));
+}
+
 .hero {
     background:
         radial-gradient(circle at 15% 0%, rgba(255, 106, 26, 0.22), transparent 36%),


### PR DESCRIPTION
### Motivation
- The homepage "Why me" (`.story-section`) used a light background in the dark theme which produced low contrast and made the section hard to read, so it needs to match the rest of the page styling.

### Description
- Added a `.story-section` rule in `css/style.css` to apply the same dark gradient background used by other elevated sections so text has proper contrast.
- The change is scoped to `css/style.css` and does not alter HTML structure or layout.

### Testing
- There is no automated test suite in this repository; this is a CSS-only visual fix and was verified by inspecting the updated `css/style.css`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e80100cca88326a1d05aaa75c1a0e1)