### PR TITLE
Restyle site with Montserrat font, dark navy/orange theme, and contact icons

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,29 +1,34 @@
+@import url('https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,400;0,500;0,600;0,700;0,800;1,700&display=swap');
+
 * {
     box-sizing: border-box;
 }
 
 :root {
-    --primary-color: #0f172a;
-    --primary-soft: #1e293b;
-    --cta-color: #f97316;
-    --accent-color: #14b8a6;
-    --accent-strong: #0f766e;
-    --surface-color: #ffffff;
-    --surface-muted: #eef2f7;
-    --surface-tint: rgba(255, 255, 255, 0.72);
-    --border-color: #d7e0ea;
-    --text-color: #0f172a;
-    --shadow-soft: 0 12px 30px rgba(15, 23, 42, 0.08);
-    --shadow-card: 0 16px 40px rgba(15, 23, 42, 0.12);
+    --primary-color: #020b2a;
+    --primary-soft: #0a173f;
+    --cta-color: #ff6b08;
+    --accent-color: #ff6b08;
+    --accent-strong: #ff8b3f;
+    --surface-color: rgba(8, 20, 62, 0.82);
+    --surface-muted: rgba(9, 27, 82, 0.82);
+    --surface-tint: rgba(10, 23, 63, 0.75);
+    --border-color: rgba(121, 152, 255, 0.2);
+    --text-color: #f7f9ff;
+    --shadow-soft: 0 14px 34px rgba(0, 0, 0, 0.36);
+    --shadow-card: 0 18px 44px rgba(0, 0, 0, 0.42);
 }
 
 body {
-    font-family: 'Roboto', sans-serif;
+    font-family: 'Montserrat', 'Roboto', sans-serif;
     margin: 0;
     padding: 0;
     line-height: 1.7;
     font-size: 18px;
-    background: radial-gradient(circle at top, #f8fafc 0%, #e2e8f0 65%, #dbeafe 100%);
+    background:
+        radial-gradient(circle at 92% 18%, rgba(255, 107, 8, 0.2), transparent 26%),
+        radial-gradient(circle at 12% 14%, rgba(72, 118, 255, 0.2), transparent 30%),
+        linear-gradient(180deg, #01061f 0%, #040b2f 48%, #020722 100%);
     color: var(--text-color);
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;
@@ -37,7 +42,7 @@ h1 {
     font-size: 2.1em;
     margin: 0.5em 0 0 0;
     text-align: center;
-    color: var(--primary-color);
+    color: #fff;
     letter-spacing: -0.02em;
 }
 
@@ -48,7 +53,7 @@ h2 {
     font-size: 1.6em;
     margin: 0.9em 0 0.5em 0;
     text-align: center;
-    color: var(--primary-color);
+    color: #fff;
 }
 h3, h4{
     text-align: center;
@@ -76,10 +81,10 @@ section {
     overflow: hidden;
     padding: clamp(2.5rem, 4vw, 4rem) 1.5rem;
     background:
-        radial-gradient(circle at top left, rgba(20, 184, 166, 0.18), transparent 35%),
-        radial-gradient(circle at top right, rgba(249, 115, 22, 0.18), transparent 32%),
-        linear-gradient(135deg, #ffffff 0%, #eff6ff 45%, #fff7ed 100%);
-    border-bottom: 1px solid var(--border-color);
+        radial-gradient(circle at top left, rgba(88, 125, 255, 0.2), transparent 35%),
+        radial-gradient(circle at top right, rgba(255, 107, 8, 0.2), transparent 32%),
+        linear-gradient(130deg, #01081f 0%, #051446 45%, #071a4f 100%);
+    border-bottom: 1px solid rgba(121, 152, 255, 0.22);
 }
 
 .hero::before,
@@ -126,9 +131,9 @@ section {
     justify-content: center;
     padding: 0.45rem 0.85rem;
     border-radius: 999px;
-    background: rgba(15, 118, 110, 0.08);
-    border: 1px solid rgba(15, 118, 110, 0.12);
-    color: var(--accent-strong);
+    background: rgba(255, 107, 8, 0.16);
+    border: 1px solid rgba(255, 107, 8, 0.35);
+    color: #ffd6be;
     font-weight: 700;
     font-size: 0.82rem;
     text-transform: uppercase;
@@ -333,7 +338,7 @@ section {
     letter-spacing: 0.12em;
     font-size: 0.75rem;
     font-weight: 700;
-    color: #475569;
+    color: #ffb17f;
     text-align: center;
     margin: 0 0 0.5rem;
 }
@@ -350,7 +355,7 @@ section {
     position: relative;
     padding-left: 2rem;
     font-weight: 500;
-    color: #1f2937;
+    color: #e2e8ff;
 }
 
 .checklist li::before {
@@ -380,20 +385,20 @@ section {
     border-radius: 16px;
     padding: 1rem 1.25rem;
     text-align: center;
-    border: 1px solid rgba(148, 163, 184, 0.2);
+    border: 1px solid rgba(121, 152, 255, 0.22);
 }
 
 .metric__value {
     display: block;
     font-size: 1.6rem;
     font-weight: 700;
-    color: var(--primary-color);
+    color: #fff;
 }
 
 .metric__label {
     display: block;
     font-size: 0.95rem;
-    color: #475569;
+    color: #c8d5ff;
     margin-top: 0.35rem;
 }
 
@@ -407,7 +412,7 @@ section {
     background: var(--surface-muted);
     border-radius: 16px;
     padding: 1.25rem;
-    border: 1px solid rgba(148, 163, 184, 0.2);
+    border: 1px solid rgba(121, 152, 255, 0.22);
     box-shadow: 0 10px 18px rgba(15, 23, 42, 0.08);
 }
 
@@ -527,7 +532,7 @@ section {
     font-size: 1.25em;
     margin: 0.5em 0;
     text-align: center;
-    color: #1f2937;
+    color: #d8e4ff;
     font-weight: 500;
 }
 
@@ -552,7 +557,7 @@ section {
     justify-content: center;
     gap: 0.5rem;
     padding: 0.85rem 1.8rem;
-    border-radius: 999px;
+    border-radius: 18px;
     font-weight: 700;
     font-size: 1rem;
     text-decoration: none;
@@ -562,7 +567,7 @@ section {
 .cta-button {
     background-color: var(--cta-color);
     color: #fff;
-    box-shadow: 0 12px 22px rgba(249, 115, 22, 0.35);
+    box-shadow: 0 12px 24px rgba(255, 107, 8, 0.42);
 }
 
 .cta-button:hover,
@@ -573,17 +578,17 @@ section {
 }
 
 .secondary-button {
-    background: #fff;
-    color: var(--primary-color);
-    border: 2px solid rgba(15, 23, 42, 0.15);
-    box-shadow: 0 8px 16px rgba(15, 23, 42, 0.12);
+    background: rgba(9, 24, 73, 0.9);
+    color: #fff;
+    border: 2px solid rgba(255, 107, 8, 0.7);
+    box-shadow: 0 10px 22px rgba(0, 0, 0, 0.33);
 }
 
 .secondary-button:hover,
 .secondary-button:focus {
     transform: translateY(-2px);
     box-shadow: 0 12px 22px rgba(15, 23, 42, 0.2);
-    color: var(--primary-color);
+    color: #fff;
 }
 
 .pricing-anchor {
@@ -620,6 +625,7 @@ img:hover {
 p {
     font-size: 1em;
     margin: 0.75em 0;
+    color: #d8e4ff;
 }
 iframe{
     margin: 0.75em 0;
@@ -662,7 +668,7 @@ nav {
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
-    background: linear-gradient(90deg, var(--primary-color), #111827);
+    background: linear-gradient(90deg, rgba(1, 8, 31, 0.95), rgba(6, 24, 82, 0.95));
     color: #fff;
     padding: 10px 0;
     box-shadow: 0 12px 24px rgba(15, 23, 42, 0.18);
@@ -689,7 +695,7 @@ nav a {
     text-decoration: none;
     font-size: 18px;
     padding: 0.25em 0.75em;
-    border-radius: 4px;
+    border-radius: 999px;
     white-space: nowrap;
     transition: background-color 0.3s ease, color 0.3s ease, transform 0.2s ease, box-shadow 0.2s ease;
 }
@@ -752,7 +758,42 @@ button:focus {
 
 .emailIG {
     font-weight: 600;
-    color: var(--primary-color);
+    color: #f5f8ff;
+}
+
+.coaching-note {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.55rem;
+}
+
+.contact-strip {
+    margin-top: 1.1rem;
+    display: inline-flex;
+    align-items: center;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.9rem;
+    padding: 0.8rem 1rem;
+    border-radius: 16px;
+    border: 1px solid rgba(121, 152, 255, 0.35);
+    background: rgba(3, 13, 45, 0.8);
+}
+
+.contact-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    font-weight: 600;
+}
+
+.contact-divider {
+    color: rgba(197, 211, 255, 0.55);
+}
+
+.contact-icon {
+    color: var(--cta-color);
+    font-size: 1.15rem;
 }
 .programButtons{
     height: 30px;
@@ -904,6 +945,10 @@ form{
     }
 
     .hero-actions {
+        justify-content: flex-start;
+    }
+
+    .contact-strip {
         justify-content: flex-start;
     }
 

--- a/index.html
+++ b/index.html
@@ -39,9 +39,12 @@
                     <a class="cta-button" href="begin.html">Start Here</a>
                     <a class="secondary-button" href="services.html#pricing">View Coaching Packages</a>
                 </div>
-                <p><strong>Coaching packages start at $149/month.</strong></p>
-                <aside><a class="emailIG" href="mailto:matthewmcginley@live.com">matthewmcginley@live.com</a> |
-                    <a class="emailIG" href="https://www.instagram.com/mattmcginley7"> Instagram</a></aside>
+                <p><strong class="coaching-note"><span class="contact-icon" aria-hidden="true">🏋️</span>Coaching packages start at $149/month.</strong></p>
+                <aside class="contact-strip">
+                    <a class="emailIG contact-item" href="mailto:matthewmcginley@live.com"><span class="contact-icon" aria-hidden="true">✉</span>matthewmcginley@live.com</a>
+                    <span class="contact-divider" aria-hidden="true">|</span>
+                    <a class="emailIG contact-item" href="https://www.instagram.com/mattmcginley7"><span class="contact-icon" aria-hidden="true">◎</span>Instagram</a>
+                </aside>
             </div>
             <div class="hero__visual">
                 <div class="hero-card">


### PR DESCRIPTION
### Motivation
- Align the site's typography and color treatment with the provided mock to create a bolder, cleaner visual identity. 
- Improve contrast and visual hierarchy in the hero, nav, cards, and CTAs while preserving all existing content and features. 
- Surface quick contact affordances (email, coaching note, Instagram) so visitors can reach out more easily.

### Description
- Import `Montserrat` from Google Fonts and update the global font stack in `css/style.css` to use `Montserrat` with fallbacks. 
- Replace and adjust color variables and background gradients to a dark navy + orange palette and update shadows/borders for stronger contrast in `css/style.css`. 
- Refine typographic and component styles (headings, paragraph color, nav pills, CTA and secondary button shapes and shadows, cards and metric contrast) in `css/style.css`. 
- Add a compact contact strip and inline icons in `index.html` and add corresponding CSS classes (`.contact-strip`, `.contact-item`, `.contact-icon`, `.coaching-note`) to style the coaching/email/Instagram items.

### Testing
- Ran `git diff --check` which returned no formatting or whitespace issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e82bbbf37c83268b1785ff6d0084e8)