### PR TITLE
Add top branded logo row to homepage nav to match mockup

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -666,15 +666,63 @@ a:focus {
 
 nav {
     display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
+    flex-direction: column;
+    align-items: center;
     background: linear-gradient(90deg, rgba(1, 8, 31, 0.95), rgba(6, 24, 82, 0.95));
     color: #fff;
-    padding: 10px 0;
+    padding: 10px 16px;
     box-shadow: 0 12px 24px rgba(15, 23, 42, 0.18);
     position: sticky;
     top: 0;
     z-index: 100;
+}
+
+.nav-top {
+    width: min(1180px, 100%);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 0.75rem;
+}
+
+.brand-logo {
+    display: inline-flex;
+    align-items: center;
+}
+
+.brand-logo img {
+    width: min(420px, 88vw);
+    height: auto;
+    display: block;
+}
+
+.nav-menu-button {
+    display: inline-flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 8px;
+    min-width: 0;
+    width: 48px;
+    height: 48px;
+    border: 0;
+    border-radius: 10px;
+    background: transparent;
+    box-shadow: none;
+    padding: 0;
+}
+
+.nav-menu-button span {
+    width: 38px;
+    height: 4px;
+    border-radius: 999px;
+    background: #fff;
+}
+
+.nav-menu-button:hover,
+.nav-menu-button:focus {
+    transform: none;
+    box-shadow: none;
 }
 
 nav ul {
@@ -2395,4 +2443,16 @@ nav a[aria-current="page"] {
 .qualifier-card h3,
 .preview-card h3 {
     color: var(--text-primary);
+}
+
+@media (min-width: 900px) {
+    .nav-menu-button {
+        display: none;
+    }
+}
+
+@media (max-width: 899px) {
+    .brand-logo img {
+        width: min(300px, 78vw);
+    }
 }

--- a/index.html
+++ b/index.html
@@ -16,6 +16,16 @@
 
 <body>
     <nav>
+        <div class="nav-top">
+            <a class="brand-logo" href="index.html" aria-label="Matt McGinley Training home">
+                <img src="PersonalTrainingAILogo.jpeg" alt="Matt McGinley Training logo">
+            </a>
+            <button class="nav-menu-button" type="button" aria-label="Open menu">
+                <span></span>
+                <span></span>
+                <span></span>
+            </button>
+        </div>
         <ul>
             <li><a href="index.html" aria-current="page">Home</a></li>
             <li><a href="about.html">About</a></li>


### PR DESCRIPTION
### Motivation
- Provide a top navigation bar that matches the supplied mockup by adding the Matt McGinley Training logo and a compact menu control while leaving the rest of the page unchanged.

### Description
- Inserted a new `.nav-top` block in `index.html` containing an anchor with the logo image (`PersonalTrainingAILogo.jpeg`) and a hamburger-style button for small screens.
- Updated `css/style.css` to stack the nav into a column layout, add `.nav-top`, `.brand-logo`, and `.nav-menu-button` styles, and adjust padding to accommodate the new top row.
- Added responsive rules to hide the hamburger button on wide viewports (`@media (min-width: 900px)`) and to scale the logo on smaller screens (`@media (max-width: 899px)`).
- Changes are scoped to the navigation/branding area only and preserve existing navigation links and page content.

### Testing
- Ran `git diff --check` to verify there are no diff-formatting issues and it returned clean.
- Confirmed the modified files were staged and committed successfully to the branch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e93d48c2b48326be5dfa4b91b06b73)