### PR TITLE
Add Matt McGinley logo to top navigation

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -677,6 +677,28 @@ nav {
     z-index: 100;
 }
 
+
+
+.nav-brand {
+    width: min(1180px, 100%);
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    padding: 0 1rem;
+    margin-bottom: 0.5rem;
+}
+
+.nav-brand a {
+    display: inline-flex;
+    align-items: center;
+}
+
+.nav-brand img {
+    display: block;
+    width: min(100%, 320px);
+    height: auto;
+}
+
 nav ul {
     list-style: none;
     margin: 0;
@@ -1775,6 +1797,15 @@ nav a[aria-current="page"] {
 
     nav {
         padding: 0.75rem 0.65rem;
+    }
+
+    .nav-brand {
+        padding: 0 0.2rem;
+        margin-bottom: 0.45rem;
+    }
+
+    .nav-brand img {
+        width: min(100%, 260px);
     }
 
     nav ul {

--- a/index.html
+++ b/index.html
@@ -16,6 +16,11 @@
 
 <body>
     <nav>
+        <div class="nav-brand">
+            <a href="index.html" aria-label="Matt McGinley Training home">
+                <img src="IMG_2070.png" alt="Matt McGinley Training logo">
+            </a>
+        </div>
         <ul>
             <li><a href="index.html" aria-current="page">Home</a></li>
             <li><a href="about.html">About</a></li>


### PR DESCRIPTION
### Motivation
- Add the Matt McGinley training logo at the top of the site to match the provided mockup while leaving all other layout and content unchanged.
- Use the available repository image asset to provide a branded top area above the navigation links.

### Description
- Inserted a `.nav-brand` block inside the `<nav>` in `index.html` that contains an anchor and an `<img>` pointing to `IMG_2070.png` so the logo appears above the nav links.
- Added scoped `.nav-brand` styles to `css/style.css` for desktop sizing and alignment and included a small mobile tweak so the logo scales appropriately without altering existing navigation behavior.
- Kept all existing navigation links and page content unchanged and limited edits to `index.html` and `css/style.css` only.

### Testing
- Ran a repository search for image references with `rg -n "IMG_2070|PersonalTrainingAILogo" *.html css/style.css` to confirm the new logo reference and existing OG image usages, which returned the expected matches.
- Verified the new logo file exists with `test -f IMG_2070.png` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9406b0718832686f77638c707fef1)