### PR TITLE
Add top logo banner to homepage to match mockup

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -664,6 +664,30 @@ a:focus {
     margin-top: 20px;
 }
 
+.site-logo-top {
+    display: flex;
+    justify-content: center;
+    padding: 0.85rem 1rem 0.55rem;
+    background: linear-gradient(90deg, rgba(1, 8, 31, 0.95), rgba(6, 24, 82, 0.95));
+}
+
+.site-logo-top__inner {
+    width: min(100%, 760px);
+    background: rgba(255, 255, 255, 0.9);
+    border-radius: 24px;
+    border: 1px solid rgba(255, 255, 255, 0.4);
+    padding: 0.95rem 1.35rem;
+    box-shadow: 0 12px 24px rgba(0, 0, 0, 0.24);
+}
+
+.site-logo-top__inner img {
+    display: block;
+    width: 100%;
+    max-width: 520px;
+    margin: 0 auto;
+    height: auto;
+}
+
 nav {
     display: flex;
     flex-wrap: wrap;
@@ -850,6 +874,15 @@ form{
 
     nav {
         padding: 0.75rem 1rem;
+    }
+
+    .site-logo-top {
+        padding: 0.75rem 0.9rem 0.45rem;
+    }
+
+    .site-logo-top__inner {
+        padding: 0.65rem 0.75rem;
+        border-radius: 18px;
     }
 
     nav ul {

--- a/index.html
+++ b/index.html
@@ -15,6 +15,12 @@
 </head>
 
 <body>
+    <div class="site-logo-top" aria-label="Matt McGinley Training logo">
+        <div class="site-logo-top__inner">
+            <img src="IMG_2073.png" alt="Matt McGinley Training logo">
+        </div>
+    </div>
+
     <nav>
         <ul>
             <li><a href="index.html" aria-current="page">Home</a></li>


### PR DESCRIPTION
### Motivation
- Add the Matt McGinley training logo to the top of the homepage so the site matches the provided mockup's top treatment (dark outer area with a centered white card containing the logo). 
- Keep all existing page structure and behavior unchanged while adding the logo banner.

### Description
- Inserted a new logo banner block above the navigation in `index.html` using a `div.site-logo-top` wrapper with an inner `div.site-logo-top__inner` that contains the logo image `IMG_2073.png`.
- Added responsive styles in `css/style.css` for `.site-logo-top`, `.site-logo-top__inner`, and `.site-logo-top__inner img` to create a rounded white card on a dark band and to cap the logo width for various viewports.
- Added small mobile adjustments in the `@media (max-width: 600px)` section to reduce padding and border-radius for the banner so it reads well on narrow screens.

### Testing
- Ran `git diff --check` to confirm there are no whitespace/patch issues and it passed. 
- Committed the changes to the working branch successfully using `git commit`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e944274a4c8326b04aafa6d0ed2ebd)