### PR TITLE
Update typography to Outfit and add Instagram SVG icon

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,400;0,500;0,600;0,700;0,800;1,700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&display=swap');
 
 * {
     box-sizing: border-box;
@@ -20,7 +20,7 @@
 }
 
 body {
-    font-family: 'Montserrat', 'Roboto', sans-serif;
+    font-family: 'Outfit', 'Roboto', sans-serif;
     margin: 0;
     padding: 0;
     line-height: 1.7;
@@ -43,7 +43,8 @@ h1 {
     margin: 0.5em 0 0 0;
     text-align: center;
     color: #fff;
-    letter-spacing: -0.02em;
+    font-weight: 800;
+    letter-spacing: -0.03em;
 }
 
 aside{
@@ -54,6 +55,8 @@ h2 {
     margin: 0.9em 0 0.5em 0;
     text-align: center;
     color: #fff;
+    font-weight: 700;
+    letter-spacing: -0.015em;
 }
 h3, h4{
     text-align: center;
@@ -533,7 +536,8 @@ section {
     margin: 0.5em 0;
     text-align: center;
     color: #d8e4ff;
-    font-weight: 500;
+    font-weight: 400;
+    letter-spacing: 0.01em;
 }
 
 .subheading {
@@ -694,6 +698,8 @@ nav a {
     color: #fff;
     text-decoration: none;
     font-size: 18px;
+    font-weight: 500;
+    letter-spacing: 0.01em;
     padding: 0.25em 0.75em;
     border-radius: 999px;
     white-space: nowrap;
@@ -794,6 +800,13 @@ button:focus {
 .contact-icon {
     color: var(--cta-color);
     font-size: 1.15rem;
+}
+
+.icon-svg {
+    width: 1.1rem;
+    height: 1.1rem;
+    display: inline-block;
+    fill: currentColor;
 }
 .programButtons{
     height: 30px;

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Roboto:wght@300;400;700&display=swap" rel="stylesheet">
     <meta name="description" content="Online training for everyday people who want to lose fat, build muscle, and get healthy.">
     <meta property="og:title" content="Matt McGinley Personal Training">
     <meta property="og:description" content="Simple online coaching for real people: lose fat, build muscle, and get strong.">
@@ -43,7 +43,7 @@
                 <aside class="contact-strip">
                     <a class="emailIG contact-item" href="mailto:matthewmcginley@live.com"><span class="contact-icon" aria-hidden="true">✉</span>matthewmcginley@live.com</a>
                     <span class="contact-divider" aria-hidden="true">|</span>
-                    <a class="emailIG contact-item" href="https://www.instagram.com/mattmcginley7"><span class="contact-icon" aria-hidden="true">◎</span>Instagram</a>
+                    <a class="emailIG contact-item" href="https://www.instagram.com/mattmcginley7"><svg class="contact-icon icon-svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M7.8 2h8.4A5.8 5.8 0 0 1 22 7.8v8.4a5.8 5.8 0 0 1-5.8 5.8H7.8A5.8 5.8 0 0 1 2 16.2V7.8A5.8 5.8 0 0 1 7.8 2Zm0 1.9A3.9 3.9 0 0 0 3.9 7.8v8.4a3.9 3.9 0 0 0 3.9 3.9h8.4a3.9 3.9 0 0 0 3.9-3.9V7.8a3.9 3.9 0 0 0-3.9-3.9H7.8Zm8.9 1.4a1.3 1.3 0 1 1 0 2.6 1.3 1.3 0 0 1 0-2.6ZM12 7a5 5 0 1 1 0 10 5 5 0 0 1 0-10Zm0 1.9a3.1 3.1 0 1 0 0 6.2 3.1 3.1 0 0 0 0-6.2Z"/></svg>Instagram</a>
                 </aside>
             </div>
             <div class="hero__visual">


### PR DESCRIPTION
### Motivation
- Refresh the site's typography to better match the provided mockup while leaving all features and layout intact. 
- Replace the placeholder Instagram glyph with a proper icon to improve visual polish in the contact strip.

### Description
- Changed the Google font import in `index.html` and swapped the site font in `css/style.css` to use `Outfit` (falling back to `Roboto`).
- Adjusted heading and nav typography in `css/style.css` by tightening letter-spacing and increasing heading weights to match the mockup's visual tone.
- Replaced the placeholder Instagram character in the contact strip with an inline SVG in `index.html` and added `.icon-svg` styling to `css/style.css` to size/color the icon correctly.
- Made only styling changes; no functional features were removed or altered.

### Testing
- Ran `git diff --check` which reported no issues and succeeded.
- Inspected repository state with `git status -sb` to confirm changes were staged and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea821330748326863448928a8fbbb1)