### PR TITLE
Add branded top navigation logo and mockup-matched top-bar styling

### DIFF
--- a/about.html
+++ b/about.html
@@ -14,7 +14,10 @@
 </head>
 
 <body>
-    <nav>
+    <nav class="site-nav">
+        <a class="site-brand" href="index.html" aria-label="Matt McGinley Training home">
+            <img src="381180AB-BEB5-4D56-95B0-6B0FF96F9CB3.png" alt="Matt McGinley Training logo">
+        </a>
         <ul>
             <li><a href="index.html">Home</a></li>
             <li><a href="about.html" aria-current="page">About</a></li>

--- a/articles.html
+++ b/articles.html
@@ -15,7 +15,10 @@
     <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
-    <nav>
+    <nav class="site-nav">
+        <a class="site-brand" href="index.html" aria-label="Matt McGinley Training home">
+            <img src="381180AB-BEB5-4D56-95B0-6B0FF96F9CB3.png" alt="Matt McGinley Training logo">
+        </a>
         <ul>
             <li><a href="index.html">Home</a></li>
             <li><a href="about.html">About</a></li>

--- a/begin.html
+++ b/begin.html
@@ -14,7 +14,10 @@
 </head>
 
 <body>
-    <nav>
+    <nav class="site-nav">
+        <a class="site-brand" href="index.html" aria-label="Matt McGinley Training home">
+            <img src="381180AB-BEB5-4D56-95B0-6B0FF96F9CB3.png" alt="Matt McGinley Training logo">
+        </a>
         <ul>
             <li><a href="index.html">Home</a></li>
             <li><a href="about.html">About</a></li>

--- a/calculators.html
+++ b/calculators.html
@@ -14,7 +14,10 @@
 </head>
 
 <body>
-    <nav>
+    <nav class="site-nav">
+        <a class="site-brand" href="index.html" aria-label="Matt McGinley Training home">
+            <img src="381180AB-BEB5-4D56-95B0-6B0FF96F9CB3.png" alt="Matt McGinley Training logo">
+        </a>
         <ul>
             <li><a href="index.html">Home</a></li>
             <li><a href="about.html">About</a></li>

--- a/css/style.css
+++ b/css/style.css
@@ -1720,6 +1720,35 @@ nav a[aria-current="page"] {
     color: #fff;
 }
 
+.site-nav {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.7rem 1rem;
+    background: linear-gradient(180deg, rgba(1, 8, 31, 0.98) 0%, rgba(2, 12, 34, 0.96) 100%);
+    border-bottom: 1px solid rgba(255, 107, 8, 0.25);
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.42);
+}
+
+.site-brand {
+    display: inline-flex;
+    align-items: center;
+    flex: 0 0 auto;
+    text-decoration: none;
+}
+
+.site-brand img {
+    display: block;
+    width: clamp(180px, 22vw, 360px);
+    max-width: 100%;
+    height: auto;
+}
+
+.site-nav ul {
+    margin-left: auto;
+}
+
 .emailIG {
     color: #ffb07a;
 }
@@ -1808,6 +1837,21 @@ nav a[aria-current="page"] {
     nav a:not([aria-current="page"]) {
         background: rgba(143, 173, 214, 0.14);
         border-color: rgba(140, 173, 211, 0.22);
+    }
+
+    .site-nav {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.65rem;
+        padding: 0.65rem 0.6rem 0.75rem;
+    }
+
+    .site-brand img {
+        width: clamp(150px, 58vw, 300px);
+    }
+
+    .site-nav ul {
+        margin-left: 0;
     }
 
     .hero-actions {

--- a/index.html
+++ b/index.html
@@ -15,7 +15,10 @@
 </head>
 
 <body>
-    <nav>
+    <nav class="site-nav">
+        <a class="site-brand" href="index.html" aria-label="Matt McGinley Training home">
+            <img src="381180AB-BEB5-4D56-95B0-6B0FF96F9CB3.png" alt="Matt McGinley Training logo">
+        </a>
         <ul>
             <li><a href="index.html" aria-current="page">Home</a></li>
             <li><a href="about.html">About</a></li>

--- a/nutrition-calculator.html
+++ b/nutrition-calculator.html
@@ -270,7 +270,10 @@
 </head>
 
 <body>
-    <nav>
+    <nav class="site-nav">
+        <a class="site-brand" href="index.html" aria-label="Matt McGinley Training home">
+            <img src="381180AB-BEB5-4D56-95B0-6B0FF96F9CB3.png" alt="Matt McGinley Training logo">
+        </a>
         <ul>
             <li><a href="index.html">Home</a></li>
             <li><a href="about.html">About</a></li>

--- a/resources.html
+++ b/resources.html
@@ -15,7 +15,10 @@
     <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
-    <nav>
+    <nav class="site-nav">
+        <a class="site-brand" href="index.html" aria-label="Matt McGinley Training home">
+            <img src="381180AB-BEB5-4D56-95B0-6B0FF96F9CB3.png" alt="Matt McGinley Training logo">
+        </a>
         <ul>
             <li><a href="index.html">Home</a></li>
             <li><a href="about.html">About</a></li>

--- a/services.html
+++ b/services.html
@@ -14,7 +14,10 @@
 </head>
 
 <body>
-    <nav>
+    <nav class="site-nav">
+        <a class="site-brand" href="index.html" aria-label="Matt McGinley Training home">
+            <img src="381180AB-BEB5-4D56-95B0-6B0FF96F9CB3.png" alt="Matt McGinley Training logo">
+        </a>
         <ul>
             <li><a href="index.html">Home</a></li>
             <li><a href="about.html">About</a></li>

--- a/workout-generator.html
+++ b/workout-generator.html
@@ -11,7 +11,10 @@
     <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
-    <nav>
+    <nav class="site-nav">
+        <a class="site-brand" href="index.html" aria-label="Matt McGinley Training home">
+            <img src="381180AB-BEB5-4D56-95B0-6B0FF96F9CB3.png" alt="Matt McGinley Training logo">
+        </a>
         <ul>
             <li><a href="index.html">Home</a></li>
             <li><a href="about.html">About</a></li>


### PR DESCRIPTION
### Motivation

- Add the supplied logo to the site header and make the top bar blend visually with the provided mockup while keeping the tab-style navigation (no hamburger) on small screens.

### Description

- Replaced the simple `<nav>` in the main pages with a reusable `nav.site-nav` structure that includes a `site-brand` link and the logo image for consistent branding across pages.
- Added `.site-nav` and `.site-brand` rules in `css/style.css` to match the mockup colors (dark gradient, subtle orange border) and set responsive image sizing so the mark blends into the top of each page.
- Updated all primary HTML pages (`index.html`, `about.html`, `services.html`, `resources.html`, `articles.html`, `calculators.html`, `workout-generator.html`, `nutrition-calculator.html`, `begin.html`) to use the new header markup while preserving the existing navigation links and current-page state.
- Included mobile-specific CSS so the logo remains visible and the horizontal tab-like nav is preserved without introducing a hamburger menu.

### Testing

- Verified the new markup and asset references across pages with `rg` and spot-checked modified regions using `nl`/`sed`; the `site-nav`/`site-brand` markup appears in all target pages and the CSS contains the new rules (verification succeeded).
- Ran a quick image inspection script which found the added PNG logo `381180AB-BEB5-4D56-95B0-6B0FF96F9CB3.png` at `2172x724` and confirmed it is present in the repo (image readouts succeeded for the PNGs).
- Confirmed repository file changes are present and the working tree reflects the updates (status check completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea87ee197483269721f1f21e7c7fce)