### PR TITLE
Add branded top-left logo to site navigation

### DIFF
--- a/about.html
+++ b/about.html
@@ -14,7 +14,10 @@
 </head>
 
 <body>
-    <nav>
+    <nav class="site-nav">
+        <a class="nav-logo" href="index.html" aria-label="Matt McGinley Training home">
+            <img src="PersonalTrainingAILogo.jpeg" alt="Matt McGinley Training logo">
+        </a>
         <ul>
             <li><a href="index.html">Home</a></li>
             <li><a href="about.html" aria-current="page">About</a></li>

--- a/articles.html
+++ b/articles.html
@@ -15,7 +15,10 @@
     <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
-    <nav>
+    <nav class="site-nav">
+        <a class="nav-logo" href="index.html" aria-label="Matt McGinley Training home">
+            <img src="PersonalTrainingAILogo.jpeg" alt="Matt McGinley Training logo">
+        </a>
         <ul>
             <li><a href="index.html">Home</a></li>
             <li><a href="about.html">About</a></li>

--- a/begin.html
+++ b/begin.html
@@ -14,7 +14,10 @@
 </head>
 
 <body>
-    <nav>
+    <nav class="site-nav">
+        <a class="nav-logo" href="index.html" aria-label="Matt McGinley Training home">
+            <img src="PersonalTrainingAILogo.jpeg" alt="Matt McGinley Training logo">
+        </a>
         <ul>
             <li><a href="index.html">Home</a></li>
             <li><a href="about.html">About</a></li>

--- a/calculators.html
+++ b/calculators.html
@@ -14,7 +14,10 @@
 </head>
 
 <body>
-    <nav>
+    <nav class="site-nav">
+        <a class="nav-logo" href="index.html" aria-label="Matt McGinley Training home">
+            <img src="PersonalTrainingAILogo.jpeg" alt="Matt McGinley Training logo">
+        </a>
         <ul>
             <li><a href="index.html">Home</a></li>
             <li><a href="about.html">About</a></li>

--- a/css/style.css
+++ b/css/style.css
@@ -668,33 +668,48 @@ a:focus {
     margin-top: 20px;
 }
 
-nav {
+.site-nav {
     display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
+    align-items: center;
+    gap: 1rem;
     background: linear-gradient(90deg, rgba(1, 8, 31, 0.95), rgba(6, 24, 82, 0.95));
     color: #fff;
-    padding: 10px 0;
+    padding: 0.7rem 1.25rem;
     box-shadow: 0 12px 24px rgba(15, 23, 42, 0.18);
     position: sticky;
     top: 0;
     z-index: 100;
 }
 
-nav ul {
+.nav-logo {
+    display: inline-flex;
+    align-items: center;
+    flex: 0 0 auto;
+    line-height: 0;
+    padding: 0;
+}
+
+.nav-logo img {
+    width: clamp(150px, 19vw, 280px);
+    height: auto;
+    object-fit: contain;
+}
+
+.site-nav ul {
     list-style: none;
     margin: 0;
     padding: 0;
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
+    flex: 1;
 }
 
-nav li {
+.site-nav li {
     margin: 0.5em 1em;
 }
 
-nav a {
+.site-nav ul a {
     color: #fff;
     text-decoration: none;
     font-size: 18px;
@@ -706,18 +721,18 @@ nav a {
     transition: background-color 0.3s ease, color 0.3s ease, transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-nav a:focus-visible {
+.site-nav ul a:focus-visible {
     outline: 3px solid rgba(255, 255, 255, 0.75);
     outline-offset: 2px;
 }
 
-nav a[aria-current="page"] {
+.site-nav ul a[aria-current="page"] {
     background: rgba(249, 115, 22, 0.95);
     color: #fff;
     box-shadow: 0 6px 14px rgba(249, 115, 22, 0.35);
 }
 
-nav a:hover {
+.site-nav ul a:hover {
     background-color: var(--cta-color);
     color: #fff;
     transform: translateY(-1px);
@@ -861,11 +876,22 @@ form{
         font-size: 1.5em;
     }
 
-    nav {
+    .site-nav {
         padding: 0.75rem 1rem;
+        gap: 0.65rem;
+        flex-direction: column;
+        align-items: stretch;
     }
 
-    nav ul {
+    .nav-logo {
+        justify-content: flex-start;
+    }
+
+    .nav-logo img {
+        width: clamp(140px, 44vw, 210px);
+    }
+
+    .site-nav ul {
         gap: 0.5rem;
         flex-wrap: nowrap;
         justify-content: flex-start;
@@ -877,22 +903,22 @@ form{
         -webkit-overflow-scrolling: touch;
     }
 
-    nav ul::-webkit-scrollbar {
+    .site-nav ul::-webkit-scrollbar {
         display: none;
     }
 
-    nav ul {
+    .site-nav ul {
         -ms-overflow-style: none;
         scrollbar-width: none;
     }
 
-    nav li {
+    .site-nav li {
         flex: 0 0 auto;
         margin: 0;
         scroll-snap-align: center;
     }
 
-    nav a {
+    .site-nav ul a {
         display: inline-flex;
         align-items: center;
         justify-content: center;
@@ -905,16 +931,16 @@ form{
         transition: transform 0.2s ease, background-color 0.3s ease;
     }
 
-    nav a[aria-current="page"] {
+    .site-nav ul a[aria-current="page"] {
         background-color: rgba(249, 115, 22, 0.95);
         border-color: rgba(249, 115, 22, 0.95);
     }
 
-    nav a:active {
+    .site-nav ul a:active {
         transform: scale(0.98);
     }
 
-    nav a:hover {
+    .site-nav ul a:hover {
         background-color: rgba(249, 115, 22, 0.85);
     }
 

--- a/index.html
+++ b/index.html
@@ -15,7 +15,10 @@
 </head>
 
 <body>
-    <nav>
+    <nav class="site-nav">
+        <a class="nav-logo" href="index.html" aria-label="Matt McGinley Training home">
+            <img src="PersonalTrainingAILogo.jpeg" alt="Matt McGinley Training logo">
+        </a>
         <ul>
             <li><a href="index.html" aria-current="page">Home</a></li>
             <li><a href="about.html">About</a></li>

--- a/resources.html
+++ b/resources.html
@@ -15,7 +15,10 @@
     <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
-    <nav>
+    <nav class="site-nav">
+        <a class="nav-logo" href="index.html" aria-label="Matt McGinley Training home">
+            <img src="PersonalTrainingAILogo.jpeg" alt="Matt McGinley Training logo">
+        </a>
         <ul>
             <li><a href="index.html">Home</a></li>
             <li><a href="about.html">About</a></li>

--- a/services.html
+++ b/services.html
@@ -14,7 +14,10 @@
 </head>
 
 <body>
-    <nav>
+    <nav class="site-nav">
+        <a class="nav-logo" href="index.html" aria-label="Matt McGinley Training home">
+            <img src="PersonalTrainingAILogo.jpeg" alt="Matt McGinley Training logo">
+        </a>
         <ul>
             <li><a href="index.html">Home</a></li>
             <li><a href="about.html">About</a></li>

--- a/workout-generator.html
+++ b/workout-generator.html
@@ -11,7 +11,10 @@
     <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
-    <nav>
+    <nav class="site-nav">
+        <a class="nav-logo" href="index.html" aria-label="Matt McGinley Training home">
+            <img src="PersonalTrainingAILogo.jpeg" alt="Matt McGinley Training logo">
+        </a>
         <ul>
             <li><a href="index.html">Home</a></li>
             <li><a href="about.html">About</a></li>


### PR DESCRIPTION
### Motivation
- Align the site header with the provided mockup by placing the brand logo at the top-left of the primary navigation. 
- Keep existing navigation behavior and accessibility while making the logo available on all core marketing pages.

### Description
- Inserted a linked logo block into the primary nav markup on `index.html`, `about.html`, `services.html`, `resources.html`, `articles.html`, `calculators.html`, `workout-generator.html`, and `begin.html` using a `.nav-logo` anchor that points to `index.html`.
- Scoped and refactored the main navigation CSS by replacing global `nav` rules with `.site-nav` and updating link selectors to `.site-nav ul a` so secondary nav components are not affected.
- Added styles for `.nav-logo` including responsive sizing (`width: clamp(...)`) and adjusted `.site-nav` layout (`gap`, `align-items`, updated padding) so menu items remain centered while the logo is left-aligned.
- Improved mobile behavior by making `.site-nav` columnar at small widths and retaining a horizontally scrollable nav link row (`.site-nav ul`) so the logo stays visible on small screens.

### Testing
- Ran `git diff --check` and it completed successfully. 
- Ran `git status --short` to confirm the intended files were changed and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea89f0de748326a6f6de6d0c7ed26e)