### PR TITLE
Add top-left logo branding to site navigation

### DIFF
--- a/about.html
+++ b/about.html
@@ -15,6 +15,9 @@
 
 <body>
     <nav>
+        <a class="nav-brand" href="index.html" aria-label="Matt McGinley Training home">
+            <img src="381180AB-BEB5-4D56-95B0-6B0FF96F9CB3.png" alt="Matt McGinley Training logo" class="nav-brand__logo">
+        </a>
         <ul>
             <li><a href="index.html">Home</a></li>
             <li><a href="about.html" aria-current="page">About</a></li>

--- a/articles.html
+++ b/articles.html
@@ -16,6 +16,9 @@
 </head>
 <body>
     <nav>
+        <a class="nav-brand" href="index.html" aria-label="Matt McGinley Training home">
+            <img src="381180AB-BEB5-4D56-95B0-6B0FF96F9CB3.png" alt="Matt McGinley Training logo" class="nav-brand__logo">
+        </a>
         <ul>
             <li><a href="index.html">Home</a></li>
             <li><a href="about.html">About</a></li>

--- a/begin.html
+++ b/begin.html
@@ -15,6 +15,9 @@
 
 <body>
     <nav>
+        <a class="nav-brand" href="index.html" aria-label="Matt McGinley Training home">
+            <img src="381180AB-BEB5-4D56-95B0-6B0FF96F9CB3.png" alt="Matt McGinley Training logo" class="nav-brand__logo">
+        </a>
         <ul>
             <li><a href="index.html">Home</a></li>
             <li><a href="about.html">About</a></li>

--- a/calculators.html
+++ b/calculators.html
@@ -15,6 +15,9 @@
 
 <body>
     <nav>
+        <a class="nav-brand" href="index.html" aria-label="Matt McGinley Training home">
+            <img src="381180AB-BEB5-4D56-95B0-6B0FF96F9CB3.png" alt="Matt McGinley Training logo" class="nav-brand__logo">
+        </a>
         <ul>
             <li><a href="index.html">Home</a></li>
             <li><a href="about.html">About</a></li>

--- a/css/style.css
+++ b/css/style.css
@@ -671,7 +671,9 @@ a:focus {
 nav {
     display: flex;
     flex-wrap: wrap;
+    align-items: center;
     justify-content: center;
+    gap: 0.75rem;
     background: linear-gradient(90deg, rgba(1, 8, 31, 0.95), rgba(6, 24, 82, 0.95));
     color: #fff;
     padding: 10px 0;
@@ -679,6 +681,27 @@ nav {
     position: sticky;
     top: 0;
     z-index: 100;
+}
+
+.nav-brand {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin-left: clamp(0.5rem, 2vw, 1.25rem);
+    margin-right: auto;
+    border-radius: 12px;
+    padding: 0.2rem;
+}
+
+.nav-brand__logo {
+    display: block;
+    width: clamp(170px, 26vw, 280px);
+    height: auto;
+}
+
+.nav-brand:focus-visible {
+    outline: 3px solid rgba(255, 255, 255, 0.75);
+    outline-offset: 3px;
 }
 
 nav ul {
@@ -863,6 +886,16 @@ form{
 
     nav {
         padding: 0.75rem 1rem;
+        gap: 0.5rem;
+    }
+
+    .nav-brand {
+        margin-left: 0;
+        margin-right: 0;
+    }
+
+    .nav-brand__logo {
+        width: clamp(145px, 44vw, 220px);
     }
 
     nav ul {
@@ -1788,6 +1821,11 @@ nav a[aria-current="page"] {
 
     nav {
         padding: 0.75rem 0.65rem;
+        gap: 0.45rem;
+    }
+
+    .nav-brand {
+        align-self: center;
     }
 
     nav ul {

--- a/index.html
+++ b/index.html
@@ -16,6 +16,9 @@
 
 <body>
     <nav>
+        <a class="nav-brand" href="index.html" aria-label="Matt McGinley Training home">
+            <img src="381180AB-BEB5-4D56-95B0-6B0FF96F9CB3.png" alt="Matt McGinley Training logo" class="nav-brand__logo">
+        </a>
         <ul>
             <li><a href="index.html" aria-current="page">Home</a></li>
             <li><a href="about.html">About</a></li>

--- a/nutrition-calculator.html
+++ b/nutrition-calculator.html
@@ -271,6 +271,9 @@
 
 <body>
     <nav>
+        <a class="nav-brand" href="index.html" aria-label="Matt McGinley Training home">
+            <img src="381180AB-BEB5-4D56-95B0-6B0FF96F9CB3.png" alt="Matt McGinley Training logo" class="nav-brand__logo">
+        </a>
         <ul>
             <li><a href="index.html">Home</a></li>
             <li><a href="about.html">About</a></li>

--- a/resources.html
+++ b/resources.html
@@ -16,6 +16,9 @@
 </head>
 <body>
     <nav>
+        <a class="nav-brand" href="index.html" aria-label="Matt McGinley Training home">
+            <img src="381180AB-BEB5-4D56-95B0-6B0FF96F9CB3.png" alt="Matt McGinley Training logo" class="nav-brand__logo">
+        </a>
         <ul>
             <li><a href="index.html">Home</a></li>
             <li><a href="about.html">About</a></li>

--- a/services.html
+++ b/services.html
@@ -15,6 +15,9 @@
 
 <body>
     <nav>
+        <a class="nav-brand" href="index.html" aria-label="Matt McGinley Training home">
+            <img src="381180AB-BEB5-4D56-95B0-6B0FF96F9CB3.png" alt="Matt McGinley Training logo" class="nav-brand__logo">
+        </a>
         <ul>
             <li><a href="index.html">Home</a></li>
             <li><a href="about.html">About</a></li>

--- a/workout-generator.html
+++ b/workout-generator.html
@@ -12,6 +12,9 @@
 </head>
 <body>
     <nav>
+        <a class="nav-brand" href="index.html" aria-label="Matt McGinley Training home">
+            <img src="381180AB-BEB5-4D56-95B0-6B0FF96F9CB3.png" alt="Matt McGinley Training logo" class="nav-brand__logo">
+        </a>
         <ul>
             <li><a href="index.html">Home</a></li>
             <li><a href="about.html">About</a></li>


### PR DESCRIPTION
### Motivation
- Place the provided logo in the top-left of the site header to match the mockup and establish consistent branding across pages.
- Keep the navigation responsive and accessible so the logo and existing menu behavior work on mobile and desktop.

### Description
- Inserted a reusable nav brand link and image (`<a class="nav-brand"><img class="nav-brand__logo" src="381180AB-BEB5-4D56-95B0-6B0FF96F9CB3.png"></a>`) into the nav of the primary pages: `index.html`, `about.html`, `services.html`, `resources.html`, `articles.html`, `calculators.html`, `workout-generator.html`, `nutrition-calculator.html`, and `begin.html`.
- Added CSS rules for `.nav-brand` and `.nav-brand__logo` and updated nav layout to left-align the logo while preserving the centered/scrolling menu behavior and spacing at different breakpoints in `css/style.css`.
- Adjusted mobile breakpoint rules so the logo scales down and the existing overflow/scroll behavior for `nav ul` remains intact.

### Testing
- Ran `git diff --check` to confirm there are no whitespace or diff errors; the check passed.
- Verified via search that the `nav-brand` element and logo source appear in all targeted pages (`rg` checks returned the expected files).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea8b17a67c8326b92e2259511763a7)