### PR TITLE
Add global header logo with responsive styling and mobile menu toggle

### DIFF
--- a/about.html
+++ b/about.html
@@ -14,8 +14,16 @@
 </head>
 
 <body>
-    <nav>
-        <ul>
+    <nav class="site-header" aria-label="Primary navigation">
+        <a class="site-header__brand" href="index.html">
+            <img src="381180AB-BEB5-4D56-95B0-6B0FF96F9CB3.png" alt="Matt McGinley Training logo" class="site-header__logo">
+        </a>
+        <button class="site-header__menu-button" type="button" aria-expanded="false" aria-controls="site-nav-list" aria-label="Toggle navigation menu">
+            <span aria-hidden="true"></span>
+            <span aria-hidden="true"></span>
+            <span aria-hidden="true"></span>
+        </button>
+        <ul id="site-nav-list">
             <li><a href="index.html">Home</a></li>
             <li><a href="about.html" aria-current="page">About</a></li>
             <li><a href="services.html">Services</a></li>

--- a/articles.html
+++ b/articles.html
@@ -15,8 +15,16 @@
     <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
-    <nav>
-        <ul>
+    <nav class="site-header" aria-label="Primary navigation">
+        <a class="site-header__brand" href="index.html">
+            <img src="381180AB-BEB5-4D56-95B0-6B0FF96F9CB3.png" alt="Matt McGinley Training logo" class="site-header__logo">
+        </a>
+        <button class="site-header__menu-button" type="button" aria-expanded="false" aria-controls="site-nav-list" aria-label="Toggle navigation menu">
+            <span aria-hidden="true"></span>
+            <span aria-hidden="true"></span>
+            <span aria-hidden="true"></span>
+        </button>
+        <ul id="site-nav-list">
             <li><a href="index.html">Home</a></li>
             <li><a href="about.html">About</a></li>
             <li><a href="services.html">Services</a></li>

--- a/begin.html
+++ b/begin.html
@@ -14,8 +14,16 @@
 </head>
 
 <body>
-    <nav>
-        <ul>
+    <nav class="site-header" aria-label="Primary navigation">
+        <a class="site-header__brand" href="index.html">
+            <img src="381180AB-BEB5-4D56-95B0-6B0FF96F9CB3.png" alt="Matt McGinley Training logo" class="site-header__logo">
+        </a>
+        <button class="site-header__menu-button" type="button" aria-expanded="false" aria-controls="site-nav-list" aria-label="Toggle navigation menu">
+            <span aria-hidden="true"></span>
+            <span aria-hidden="true"></span>
+            <span aria-hidden="true"></span>
+        </button>
+        <ul id="site-nav-list">
             <li><a href="index.html">Home</a></li>
             <li><a href="about.html">About</a></li>
             <li><a href="services.html">Services</a></li>

--- a/calculators.html
+++ b/calculators.html
@@ -14,8 +14,16 @@
 </head>
 
 <body>
-    <nav>
-        <ul>
+    <nav class="site-header" aria-label="Primary navigation">
+        <a class="site-header__brand" href="index.html">
+            <img src="381180AB-BEB5-4D56-95B0-6B0FF96F9CB3.png" alt="Matt McGinley Training logo" class="site-header__logo">
+        </a>
+        <button class="site-header__menu-button" type="button" aria-expanded="false" aria-controls="site-nav-list" aria-label="Toggle navigation menu">
+            <span aria-hidden="true"></span>
+            <span aria-hidden="true"></span>
+            <span aria-hidden="true"></span>
+        </button>
+        <ul id="site-nav-list">
             <li><a href="index.html">Home</a></li>
             <li><a href="about.html">About</a></li>
             <li><a href="services.html">Services</a></li>

--- a/css/style.css
+++ b/css/style.css
@@ -2415,9 +2415,13 @@ nav a[aria-current="page"] {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: 0.75rem;
-    flex-wrap: nowrap;
-    padding: 0.75rem 0.9rem;
+    gap: 0.8rem;
+    flex-wrap: wrap;
+    min-height: 76px;
+    padding: 14px 22px;
+    background: #050b14;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+    backdrop-filter: none;
 }
 
 .site-header__brand {
@@ -2428,9 +2432,9 @@ nav a[aria-current="page"] {
 }
 
 .site-header__logo {
-    width: clamp(180px, 58vw, 360px);
-    max-width: 100%;
-    max-height: 64px;
+    width: clamp(190px, 56vw, 230px);
+    max-width: 65vw;
+    max-height: 48px;
     height: auto;
     object-fit: contain;
     display: block;
@@ -2442,26 +2446,35 @@ nav a[aria-current="page"] {
     justify-content: center;
     flex-direction: column;
     gap: 0.28rem;
-    width: 44px;
-    height: 44px;
-    border-radius: 12px;
-    border: 1px solid rgba(140, 173, 211, 0.45);
-    background: rgba(10, 26, 49, 0.9);
-    min-width: 44px;
+    width: 48px;
+    height: 48px;
+    border-radius: 16px;
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    background: rgba(255, 255, 255, 0.04);
+    min-width: 48px;
     padding: 0;
     box-shadow: none;
+    flex: 0 0 auto;
 }
 
 .site-header__menu-button span {
-    width: 22px;
+    width: 20px;
     height: 2px;
-    background: #f7fbff;
+    background: #fff;
     border-radius: 999px;
+}
+
+.site-header ul {
+    background: transparent;
+    border: none;
+    border-radius: 0;
+    padding: 0;
 }
 
 @media (max-width: 600px) {
     .site-header {
-        align-items: flex-start;
+        min-height: 72px;
+        padding: 14px 20px;
     }
 
     .site-header__menu-button {
@@ -2469,17 +2482,40 @@ nav a[aria-current="page"] {
     }
 
     .site-header__logo {
-        width: clamp(160px, 54vw, 300px);
-        max-height: 56px;
+        width: clamp(190px, 56vw, 230px);
+        max-width: 65vw;
+        max-height: 48px;
     }
 
     .site-header ul {
         display: none;
         width: 100%;
-        margin-top: 0.65rem;
+        margin-top: 0.6rem;
     }
 
     .site-header.site-header--open ul {
         display: flex;
+        border-radius: 18px;
+        padding: 0.35rem;
+        background: rgba(5, 22, 44, 0.88);
+        border: 1px solid rgba(124, 161, 206, 0.26);
+    }
+}
+
+@media (max-width: 380px) {
+    .site-header {
+        padding-inline: 16px;
+    }
+
+    .site-header__logo {
+        width: clamp(165px, 54vw, 210px);
+        max-height: 44px;
+    }
+
+    .site-header__menu-button {
+        width: 44px;
+        height: 44px;
+        min-width: 44px;
+        border-radius: 14px;
     }
 }

--- a/css/style.css
+++ b/css/style.css
@@ -2409,3 +2409,77 @@ nav a[aria-current="page"] {
 .preview-card h3 {
     color: var(--text-primary);
 }
+
+/* Global site header branding */
+.site-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    flex-wrap: nowrap;
+    padding: 0.75rem 0.9rem;
+}
+
+.site-header__brand {
+    display: inline-flex;
+    align-items: center;
+    flex: 0 1 auto;
+    min-width: 0;
+}
+
+.site-header__logo {
+    width: clamp(180px, 58vw, 360px);
+    max-width: 100%;
+    max-height: 64px;
+    height: auto;
+    object-fit: contain;
+    display: block;
+}
+
+.site-header__menu-button {
+    display: none;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+    gap: 0.28rem;
+    width: 44px;
+    height: 44px;
+    border-radius: 12px;
+    border: 1px solid rgba(140, 173, 211, 0.45);
+    background: rgba(10, 26, 49, 0.9);
+    min-width: 44px;
+    padding: 0;
+    box-shadow: none;
+}
+
+.site-header__menu-button span {
+    width: 22px;
+    height: 2px;
+    background: #f7fbff;
+    border-radius: 999px;
+}
+
+@media (max-width: 600px) {
+    .site-header {
+        align-items: flex-start;
+    }
+
+    .site-header__menu-button {
+        display: inline-flex;
+    }
+
+    .site-header__logo {
+        width: clamp(160px, 54vw, 300px);
+        max-height: 56px;
+    }
+
+    .site-header ul {
+        display: none;
+        width: 100%;
+        margin-top: 0.65rem;
+    }
+
+    .site-header.site-header--open ul {
+        display: flex;
+    }
+}

--- a/index.html
+++ b/index.html
@@ -15,8 +15,16 @@
 </head>
 
 <body>
-    <nav>
-        <ul>
+    <nav class="site-header" aria-label="Primary navigation">
+        <a class="site-header__brand" href="index.html">
+            <img src="381180AB-BEB5-4D56-95B0-6B0FF96F9CB3.png" alt="Matt McGinley Training logo" class="site-header__logo">
+        </a>
+        <button class="site-header__menu-button" type="button" aria-expanded="false" aria-controls="site-nav-list" aria-label="Toggle navigation menu">
+            <span aria-hidden="true"></span>
+            <span aria-hidden="true"></span>
+            <span aria-hidden="true"></span>
+        </button>
+        <ul id="site-nav-list">
             <li><a href="index.html" aria-current="page">Home</a></li>
             <li><a href="about.html">About</a></li>
             <li><a href="services.html">Services</a></li>

--- a/js/main.js
+++ b/js/main.js
@@ -198,6 +198,16 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
 
+
+    var siteHeader = document.querySelector('.site-header');
+    var siteMenuButton = document.querySelector('.site-header__menu-button');
+    if (siteHeader && siteMenuButton) {
+        siteMenuButton.addEventListener('click', function () {
+            var isOpen = siteHeader.classList.toggle('site-header--open');
+            siteMenuButton.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+        });
+    }
+
     var goalConfig = {
         'fat-loss': {
             title: 'Start with consistent training + a manageable calorie deficit',

--- a/nutrition-calculator.html
+++ b/nutrition-calculator.html
@@ -270,8 +270,16 @@
 </head>
 
 <body>
-    <nav>
-        <ul>
+    <nav class="site-header" aria-label="Primary navigation">
+        <a class="site-header__brand" href="index.html">
+            <img src="381180AB-BEB5-4D56-95B0-6B0FF96F9CB3.png" alt="Matt McGinley Training logo" class="site-header__logo">
+        </a>
+        <button class="site-header__menu-button" type="button" aria-expanded="false" aria-controls="site-nav-list" aria-label="Toggle navigation menu">
+            <span aria-hidden="true"></span>
+            <span aria-hidden="true"></span>
+            <span aria-hidden="true"></span>
+        </button>
+        <ul id="site-nav-list">
             <li><a href="index.html">Home</a></li>
             <li><a href="about.html">About</a></li>
             <li><a href="services.html">Services</a></li>

--- a/resources.html
+++ b/resources.html
@@ -15,8 +15,16 @@
     <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
-    <nav>
-        <ul>
+    <nav class="site-header" aria-label="Primary navigation">
+        <a class="site-header__brand" href="index.html">
+            <img src="381180AB-BEB5-4D56-95B0-6B0FF96F9CB3.png" alt="Matt McGinley Training logo" class="site-header__logo">
+        </a>
+        <button class="site-header__menu-button" type="button" aria-expanded="false" aria-controls="site-nav-list" aria-label="Toggle navigation menu">
+            <span aria-hidden="true"></span>
+            <span aria-hidden="true"></span>
+            <span aria-hidden="true"></span>
+        </button>
+        <ul id="site-nav-list">
             <li><a href="index.html">Home</a></li>
             <li><a href="about.html">About</a></li>
             <li><a href="services.html">Services</a></li>

--- a/services.html
+++ b/services.html
@@ -14,8 +14,16 @@
 </head>
 
 <body>
-    <nav>
-        <ul>
+    <nav class="site-header" aria-label="Primary navigation">
+        <a class="site-header__brand" href="index.html">
+            <img src="381180AB-BEB5-4D56-95B0-6B0FF96F9CB3.png" alt="Matt McGinley Training logo" class="site-header__logo">
+        </a>
+        <button class="site-header__menu-button" type="button" aria-expanded="false" aria-controls="site-nav-list" aria-label="Toggle navigation menu">
+            <span aria-hidden="true"></span>
+            <span aria-hidden="true"></span>
+            <span aria-hidden="true"></span>
+        </button>
+        <ul id="site-nav-list">
             <li><a href="index.html">Home</a></li>
             <li><a href="about.html">About</a></li>
             <li><a href="services.html" aria-current="page">Services</a></li>

--- a/workout-generator.html
+++ b/workout-generator.html
@@ -11,8 +11,16 @@
     <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
-    <nav>
-        <ul>
+    <nav class="site-header" aria-label="Primary navigation">
+        <a class="site-header__brand" href="index.html">
+            <img src="381180AB-BEB5-4D56-95B0-6B0FF96F9CB3.png" alt="Matt McGinley Training logo" class="site-header__logo">
+        </a>
+        <button class="site-header__menu-button" type="button" aria-expanded="false" aria-controls="site-nav-list" aria-label="Toggle navigation menu">
+            <span aria-hidden="true"></span>
+            <span aria-hidden="true"></span>
+            <span aria-hidden="true"></span>
+        </button>
+        <ul id="site-nav-list">
             <li><a href="index.html">Home</a></li>
             <li><a href="about.html">About</a></li>
             <li><a href="services.html">Services</a></li>


### PR DESCRIPTION
### Motivation
- Replace the existing text/logo treatment with the provided transparent logo image so branding is consistent across every page. 
- Keep the header layout mobile-first and ensure the logo scales cleanly without stretching, cropping, or hiding the menu control. 
- Preserve all existing pages, links, and features while improving header accessibility and responsive behavior.

### Description
- Replaced the top-left navigation markup on all primary pages with a shared header structure that includes a brand link and an `<img>` element using `381180AB-BEB5-4D56-95B0-6B0FF96F9CB3.png` and the alt text `Matt McGinley Training logo`. 
- Added responsive CSS rules in `css/style.css` under `.site-header`, `.site-header__logo`, and `.site-header__menu-button` using `display: flex`, `justify-content: space-between`, `width: clamp(...)`, `max-height`, `height: auto`, and `object-fit: contain` to avoid stretching or cropping and to scale for small screens. 
- Inserted a small, accessible mobile menu button into the header markup and added JavaScript in `js/main.js` to toggle `site-header--open` and update `aria-expanded` so the nav list can be shown/hidden on mobile without removing any links. 
- Updated the following files to the new header structure while preserving existing content and link order: `index.html`, `about.html`, `services.html`, `resources.html`, `articles.html`, `calculators.html`, `workout-generator.html`, `nutrition-calculator.html`, and `begin.html`.

### Testing
- Ran `git status --short` to verify changed files, which completed successfully. 
- Committed the changes with `git commit -m "Update global header branding with new logo image"`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f125522b1c8326918c23a0d8519589)