### PR TITLE
Redesign global header with branded hamburger navigation

### DIFF
--- a/about.html
+++ b/about.html
@@ -14,17 +14,24 @@
 </head>
 
 <body>
-    <nav>
-        <ul>
-            <li><a href="index.html">Home</a></li>
-            <li><a href="about.html" aria-current="page">About</a></li>
-            <li><a href="services.html">Services</a></li>
-            <li><a href="resources.html">Resources</a></li>
-            <li><a href="articles.html">Articles</a></li>
-            <li><a href="calculators.html">Calculators</a></li>
-            <li><a href="workout-generator.html">Workout Generator</a></li>
-            <li><a href="nutrition-calculator.html">Nutrition Calculator</a></li>
-            <li><a href="begin.html">Begin</a></li>
+    <nav class="site-nav">
+        <a class="site-brand" href="index.html" aria-label="Matt McGinley Personal Training home">
+            <span class="site-brand__mark" aria-hidden="true">MM</span>
+            <span class="site-brand__text">Matt McGinley Personal Training</span>
+        </a>
+        <button class="site-nav__toggle" type="button" aria-expanded="false" aria-controls="site-menu" aria-label="Open navigation menu">
+            <span class="site-nav__hamburger" aria-hidden="true"></span>
+        </button>
+        <ul id="site-menu" class="site-nav__menu">
+                <li><a href="index.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 10.5 12 3l9 7.5v9a1.5 1.5 0 0 1-1.5 1.5h-5.25V14h-4.5v7H4.5A1.5 1.5 0 0 1 3 19.5z"/></svg></span><span>Home</span></a></li>
+                <li><a href="about.html" aria-current="page"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 12a4.5 4.5 0 1 0-4.5-4.5A4.5 4.5 0 0 0 12 12zm0 2.25c-3.75 0-6.75 1.88-6.75 4.2V21h13.5v-2.55c0-2.32-3-4.2-6.75-4.2z"/></svg></span><span>About</span></a></li>
+                <li><a href="services.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4.5 6.75h15v3h-15zm0 5.25h15v3h-15zm0 5.25h15v3h-15z"/></svg></span><span>Services</span></a></li>
+                <li><a href="resources.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5.25 4.5h13.5A1.5 1.5 0 0 1 20.25 6v12a1.5 1.5 0 0 1-1.5 1.5H8.25l-4.5-4.5V6a1.5 1.5 0 0 1 1.5-1.5zm3 13.5v-3h-3z"/></svg></span><span>Resources</span></a></li>
+                <li><a href="articles.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5.25 4.5h13.5v15h-13.5zm3 3v1.5h7.5V7.5zm0 3.75v1.5h7.5v-1.5zm0 3.75v1.5h5.25V15z"/></svg></span><span>Articles</span></a></li>
+                <li><a href="calculators.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 3.75h12A2.25 2.25 0 0 1 20.25 6v12A2.25 2.25 0 0 1 18 20.25H6A2.25 2.25 0 0 1 3.75 18V6A2.25 2.25 0 0 1 6 3.75zm1.5 3v3h9v-3zm0 4.5v1.5H9v-1.5zm3 0v1.5h1.5v-1.5zm3 0v1.5H15v-1.5zm-6 3v1.5H9v-1.5zm3 0v1.5h1.5v-1.5zm3 0v1.5H15v-1.5z"/></svg></span><span>Calculators</span></a></li>
+                <li><a href="workout-generator.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M2.25 9h3v6h-3zm16.5 0h3v6h-3zM6 10.5h12v3H6zm1.5-3h2.25v9H7.5zm6.75 0h2.25v9h-2.25z"/></svg></span><span>Workout Generator</span></a></li>
+                <li><a href="nutrition-calculator.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M7.5 3.75a3.75 3.75 0 0 1 3.75 3.75c0 1.6-1.01 3.05-2.45 3.57l.95 8.68H6.3l.95-8.68A3.75 3.75 0 0 1 7.5 3.75zm8.25 0c.41 0 .75.34.75.75v15.75h-1.5V12h-2.25V4.5c0-.41.34-.75.75-.75z"/></svg></span><span>Nutrition Calculator</span></a></li>
+                <li><a href="begin.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="m8.25 5.25 9 6.75-9 6.75z"/></svg></span><span>Begin</span></a></li>
         </ul>
     </nav>
     <header class="hero">

--- a/articles.html
+++ b/articles.html
@@ -15,17 +15,24 @@
     <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
-    <nav>
-        <ul>
-            <li><a href="index.html">Home</a></li>
-            <li><a href="about.html">About</a></li>
-            <li><a href="services.html">Services</a></li>
-            <li><a href="resources.html">Resources</a></li>
-            <li><a href="articles.html" aria-current="page">Articles</a></li>
-            <li><a href="calculators.html">Calculators</a></li>
-            <li><a href="workout-generator.html">Workout Generator</a></li>
-            <li><a href="nutrition-calculator.html">Nutrition Calculator</a></li>
-            <li><a href="begin.html">Begin</a></li>
+    <nav class="site-nav">
+        <a class="site-brand" href="index.html" aria-label="Matt McGinley Personal Training home">
+            <span class="site-brand__mark" aria-hidden="true">MM</span>
+            <span class="site-brand__text">Matt McGinley Personal Training</span>
+        </a>
+        <button class="site-nav__toggle" type="button" aria-expanded="false" aria-controls="site-menu" aria-label="Open navigation menu">
+            <span class="site-nav__hamburger" aria-hidden="true"></span>
+        </button>
+        <ul id="site-menu" class="site-nav__menu">
+                <li><a href="index.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 10.5 12 3l9 7.5v9a1.5 1.5 0 0 1-1.5 1.5h-5.25V14h-4.5v7H4.5A1.5 1.5 0 0 1 3 19.5z"/></svg></span><span>Home</span></a></li>
+                <li><a href="about.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 12a4.5 4.5 0 1 0-4.5-4.5A4.5 4.5 0 0 0 12 12zm0 2.25c-3.75 0-6.75 1.88-6.75 4.2V21h13.5v-2.55c0-2.32-3-4.2-6.75-4.2z"/></svg></span><span>About</span></a></li>
+                <li><a href="services.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4.5 6.75h15v3h-15zm0 5.25h15v3h-15zm0 5.25h15v3h-15z"/></svg></span><span>Services</span></a></li>
+                <li><a href="resources.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5.25 4.5h13.5A1.5 1.5 0 0 1 20.25 6v12a1.5 1.5 0 0 1-1.5 1.5H8.25l-4.5-4.5V6a1.5 1.5 0 0 1 1.5-1.5zm3 13.5v-3h-3z"/></svg></span><span>Resources</span></a></li>
+                <li><a href="articles.html" aria-current="page"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5.25 4.5h13.5v15h-13.5zm3 3v1.5h7.5V7.5zm0 3.75v1.5h7.5v-1.5zm0 3.75v1.5h5.25V15z"/></svg></span><span>Articles</span></a></li>
+                <li><a href="calculators.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 3.75h12A2.25 2.25 0 0 1 20.25 6v12A2.25 2.25 0 0 1 18 20.25H6A2.25 2.25 0 0 1 3.75 18V6A2.25 2.25 0 0 1 6 3.75zm1.5 3v3h9v-3zm0 4.5v1.5H9v-1.5zm3 0v1.5h1.5v-1.5zm3 0v1.5H15v-1.5zm-6 3v1.5H9v-1.5zm3 0v1.5h1.5v-1.5zm3 0v1.5H15v-1.5z"/></svg></span><span>Calculators</span></a></li>
+                <li><a href="workout-generator.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M2.25 9h3v6h-3zm16.5 0h3v6h-3zM6 10.5h12v3H6zm1.5-3h2.25v9H7.5zm6.75 0h2.25v9h-2.25z"/></svg></span><span>Workout Generator</span></a></li>
+                <li><a href="nutrition-calculator.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M7.5 3.75a3.75 3.75 0 0 1 3.75 3.75c0 1.6-1.01 3.05-2.45 3.57l.95 8.68H6.3l.95-8.68A3.75 3.75 0 0 1 7.5 3.75zm8.25 0c.41 0 .75.34.75.75v15.75h-1.5V12h-2.25V4.5c0-.41.34-.75.75-.75z"/></svg></span><span>Nutrition Calculator</span></a></li>
+                <li><a href="begin.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="m8.25 5.25 9 6.75-9 6.75z"/></svg></span><span>Begin</span></a></li>
         </ul>
     </nav>
     <header class="hero">

--- a/begin.html
+++ b/begin.html
@@ -14,17 +14,24 @@
 </head>
 
 <body>
-    <nav>
-        <ul>
-            <li><a href="index.html">Home</a></li>
-            <li><a href="about.html">About</a></li>
-            <li><a href="services.html">Services</a></li>
-            <li><a href="resources.html">Resources</a></li>
-            <li><a href="articles.html">Articles</a></li>
-            <li><a href="calculators.html">Calculators</a></li>
-            <li><a href="workout-generator.html">Workout Generator</a></li>
-            <li><a href="nutrition-calculator.html">Nutrition Calculator</a></li>
-            <li><a href="begin.html" aria-current="page">Begin</a></li>
+    <nav class="site-nav">
+        <a class="site-brand" href="index.html" aria-label="Matt McGinley Personal Training home">
+            <span class="site-brand__mark" aria-hidden="true">MM</span>
+            <span class="site-brand__text">Matt McGinley Personal Training</span>
+        </a>
+        <button class="site-nav__toggle" type="button" aria-expanded="false" aria-controls="site-menu" aria-label="Open navigation menu">
+            <span class="site-nav__hamburger" aria-hidden="true"></span>
+        </button>
+        <ul id="site-menu" class="site-nav__menu">
+                <li><a href="index.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 10.5 12 3l9 7.5v9a1.5 1.5 0 0 1-1.5 1.5h-5.25V14h-4.5v7H4.5A1.5 1.5 0 0 1 3 19.5z"/></svg></span><span>Home</span></a></li>
+                <li><a href="about.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 12a4.5 4.5 0 1 0-4.5-4.5A4.5 4.5 0 0 0 12 12zm0 2.25c-3.75 0-6.75 1.88-6.75 4.2V21h13.5v-2.55c0-2.32-3-4.2-6.75-4.2z"/></svg></span><span>About</span></a></li>
+                <li><a href="services.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4.5 6.75h15v3h-15zm0 5.25h15v3h-15zm0 5.25h15v3h-15z"/></svg></span><span>Services</span></a></li>
+                <li><a href="resources.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5.25 4.5h13.5A1.5 1.5 0 0 1 20.25 6v12a1.5 1.5 0 0 1-1.5 1.5H8.25l-4.5-4.5V6a1.5 1.5 0 0 1 1.5-1.5zm3 13.5v-3h-3z"/></svg></span><span>Resources</span></a></li>
+                <li><a href="articles.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5.25 4.5h13.5v15h-13.5zm3 3v1.5h7.5V7.5zm0 3.75v1.5h7.5v-1.5zm0 3.75v1.5h5.25V15z"/></svg></span><span>Articles</span></a></li>
+                <li><a href="calculators.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 3.75h12A2.25 2.25 0 0 1 20.25 6v12A2.25 2.25 0 0 1 18 20.25H6A2.25 2.25 0 0 1 3.75 18V6A2.25 2.25 0 0 1 6 3.75zm1.5 3v3h9v-3zm0 4.5v1.5H9v-1.5zm3 0v1.5h1.5v-1.5zm3 0v1.5H15v-1.5zm-6 3v1.5H9v-1.5zm3 0v1.5h1.5v-1.5zm3 0v1.5H15v-1.5z"/></svg></span><span>Calculators</span></a></li>
+                <li><a href="workout-generator.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M2.25 9h3v6h-3zm16.5 0h3v6h-3zM6 10.5h12v3H6zm1.5-3h2.25v9H7.5zm6.75 0h2.25v9h-2.25z"/></svg></span><span>Workout Generator</span></a></li>
+                <li><a href="nutrition-calculator.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M7.5 3.75a3.75 3.75 0 0 1 3.75 3.75c0 1.6-1.01 3.05-2.45 3.57l.95 8.68H6.3l.95-8.68A3.75 3.75 0 0 1 7.5 3.75zm8.25 0c.41 0 .75.34.75.75v15.75h-1.5V12h-2.25V4.5c0-.41.34-.75.75-.75z"/></svg></span><span>Nutrition Calculator</span></a></li>
+                <li><a href="begin.html" aria-current="page"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="m8.25 5.25 9 6.75-9 6.75z"/></svg></span><span>Begin</span></a></li>
         </ul>
     </nav>
 

--- a/calculators.html
+++ b/calculators.html
@@ -14,17 +14,24 @@
 </head>
 
 <body>
-    <nav>
-        <ul>
-            <li><a href="index.html">Home</a></li>
-            <li><a href="about.html">About</a></li>
-            <li><a href="services.html">Services</a></li>
-            <li><a href="resources.html">Resources</a></li>
-            <li><a href="articles.html">Articles</a></li>
-            <li><a href="calculators.html" aria-current="page">Calculators</a></li>
-            <li><a href="workout-generator.html">Workout Generator</a></li>
-            <li><a href="nutrition-calculator.html">Nutrition Calculator</a></li>
-            <li><a href="begin.html">Begin</a></li>
+    <nav class="site-nav">
+        <a class="site-brand" href="index.html" aria-label="Matt McGinley Personal Training home">
+            <span class="site-brand__mark" aria-hidden="true">MM</span>
+            <span class="site-brand__text">Matt McGinley Personal Training</span>
+        </a>
+        <button class="site-nav__toggle" type="button" aria-expanded="false" aria-controls="site-menu" aria-label="Open navigation menu">
+            <span class="site-nav__hamburger" aria-hidden="true"></span>
+        </button>
+        <ul id="site-menu" class="site-nav__menu">
+                <li><a href="index.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 10.5 12 3l9 7.5v9a1.5 1.5 0 0 1-1.5 1.5h-5.25V14h-4.5v7H4.5A1.5 1.5 0 0 1 3 19.5z"/></svg></span><span>Home</span></a></li>
+                <li><a href="about.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 12a4.5 4.5 0 1 0-4.5-4.5A4.5 4.5 0 0 0 12 12zm0 2.25c-3.75 0-6.75 1.88-6.75 4.2V21h13.5v-2.55c0-2.32-3-4.2-6.75-4.2z"/></svg></span><span>About</span></a></li>
+                <li><a href="services.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4.5 6.75h15v3h-15zm0 5.25h15v3h-15zm0 5.25h15v3h-15z"/></svg></span><span>Services</span></a></li>
+                <li><a href="resources.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5.25 4.5h13.5A1.5 1.5 0 0 1 20.25 6v12a1.5 1.5 0 0 1-1.5 1.5H8.25l-4.5-4.5V6a1.5 1.5 0 0 1 1.5-1.5zm3 13.5v-3h-3z"/></svg></span><span>Resources</span></a></li>
+                <li><a href="articles.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5.25 4.5h13.5v15h-13.5zm3 3v1.5h7.5V7.5zm0 3.75v1.5h7.5v-1.5zm0 3.75v1.5h5.25V15z"/></svg></span><span>Articles</span></a></li>
+                <li><a href="calculators.html" aria-current="page"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 3.75h12A2.25 2.25 0 0 1 20.25 6v12A2.25 2.25 0 0 1 18 20.25H6A2.25 2.25 0 0 1 3.75 18V6A2.25 2.25 0 0 1 6 3.75zm1.5 3v3h9v-3zm0 4.5v1.5H9v-1.5zm3 0v1.5h1.5v-1.5zm3 0v1.5H15v-1.5zm-6 3v1.5H9v-1.5zm3 0v1.5h1.5v-1.5zm3 0v1.5H15v-1.5z"/></svg></span><span>Calculators</span></a></li>
+                <li><a href="workout-generator.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M2.25 9h3v6h-3zm16.5 0h3v6h-3zM6 10.5h12v3H6zm1.5-3h2.25v9H7.5zm6.75 0h2.25v9h-2.25z"/></svg></span><span>Workout Generator</span></a></li>
+                <li><a href="nutrition-calculator.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M7.5 3.75a3.75 3.75 0 0 1 3.75 3.75c0 1.6-1.01 3.05-2.45 3.57l.95 8.68H6.3l.95-8.68A3.75 3.75 0 0 1 7.5 3.75zm8.25 0c.41 0 .75.34.75.75v15.75h-1.5V12h-2.25V4.5c0-.41.34-.75.75-.75z"/></svg></span><span>Nutrition Calculator</span></a></li>
+                <li><a href="begin.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="m8.25 5.25 9 6.75-9 6.75z"/></svg></span><span>Begin</span></a></li>
         </ul>
     </nav>
     <header class="hero">

--- a/css/style.css
+++ b/css/style.css
@@ -914,9 +914,9 @@ form{
         transform: scale(0.98);
     }
 
-    nav a:hover {
-        background-color: rgba(249, 115, 22, 0.85);
-    }
+nav a:hover {
+    background-color: rgba(249, 115, 22, 0.85);
+}
 
     #edCoanPhaseParagraph {
         padding-top: 10px;
@@ -939,6 +939,113 @@ form{
     textarea {
         max-width: 100%;
     }
+}
+
+.site-nav {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.85rem 1rem;
+    position: sticky;
+}
+
+.site-brand {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.65rem;
+    text-decoration: none;
+    color: #fff;
+}
+
+.site-brand__mark {
+    width: 2.2rem;
+    height: 2.2rem;
+    border: 1px solid rgba(255, 255, 255, 0.55);
+    border-radius: 999px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 700;
+    font-size: 0.85rem;
+    letter-spacing: 0.04em;
+}
+
+.site-brand__text {
+    font-size: 0.95rem;
+    font-weight: 600;
+    line-height: 1.2;
+}
+
+.site-nav__toggle {
+    min-width: 44px;
+    width: 44px;
+    height: 44px;
+    padding: 0;
+    border: 1px solid rgba(255, 255, 255, 0.35);
+    background: rgba(255, 255, 255, 0.08);
+    box-shadow: none;
+}
+
+.site-nav__hamburger,
+.site-nav__hamburger::before,
+.site-nav__hamburger::after {
+    content: "";
+    display: block;
+    width: 18px;
+    height: 2px;
+    background: #fff;
+    border-radius: 999px;
+    margin: 0 auto;
+    transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.site-nav__hamburger::before { transform: translateY(-6px); }
+.site-nav__hamburger::after { transform: translateY(4px); }
+
+.site-nav__menu {
+    display: none;
+    position: absolute;
+    top: calc(100% + 0.35rem);
+    right: 1rem;
+    width: min(320px, calc(100vw - 2rem));
+    background: rgba(3, 13, 45, 0.98);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 16px;
+    padding: 0.45rem;
+    flex-direction: column;
+    gap: 0.2rem;
+}
+
+.site-nav.is-open .site-nav__menu { display: flex; }
+
+.site-nav__menu li { margin: 0; }
+
+.site-nav__menu a {
+    display: flex;
+    justify-content: flex-start;
+    align-items: center;
+    gap: 0.65rem;
+    width: 100%;
+    padding: 0.55rem 0.7rem;
+    border-radius: 10px;
+}
+
+.nav-icon {
+    width: 0.95rem;
+    height: 0.95rem;
+    color: #fff;
+    display: inline-flex;
+    flex-shrink: 0;
+}
+
+.nav-icon svg {
+    width: 100%;
+    height: 100%;
+    fill: currentColor;
+}
+
+@media (min-width: 900px) {
+    .site-brand__text { font-size: 1rem; }
 }
 
 @media (min-width: 768px) {

--- a/index.html
+++ b/index.html
@@ -15,17 +15,24 @@
 </head>
 
 <body>
-    <nav>
-        <ul>
-            <li><a href="index.html" aria-current="page">Home</a></li>
-            <li><a href="about.html">About</a></li>
-            <li><a href="services.html">Services</a></li>
-            <li><a href="resources.html">Resources</a></li>
-            <li><a href="articles.html">Articles</a></li>
-            <li><a href="calculators.html">Calculators</a></li>
-            <li><a href="workout-generator.html">Workout Generator</a></li>
-            <li><a href="nutrition-calculator.html">Nutrition Calculator</a></li>
-            <li><a href="begin.html">Begin</a></li>
+    <nav class="site-nav">
+        <a class="site-brand" href="index.html" aria-label="Matt McGinley Personal Training home">
+            <span class="site-brand__mark" aria-hidden="true">MM</span>
+            <span class="site-brand__text">Matt McGinley Personal Training</span>
+        </a>
+        <button class="site-nav__toggle" type="button" aria-expanded="false" aria-controls="site-menu" aria-label="Open navigation menu">
+            <span class="site-nav__hamburger" aria-hidden="true"></span>
+        </button>
+        <ul id="site-menu" class="site-nav__menu">
+                <li><a href="index.html" aria-current="page"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 10.5 12 3l9 7.5v9a1.5 1.5 0 0 1-1.5 1.5h-5.25V14h-4.5v7H4.5A1.5 1.5 0 0 1 3 19.5z"/></svg></span><span>Home</span></a></li>
+                <li><a href="about.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 12a4.5 4.5 0 1 0-4.5-4.5A4.5 4.5 0 0 0 12 12zm0 2.25c-3.75 0-6.75 1.88-6.75 4.2V21h13.5v-2.55c0-2.32-3-4.2-6.75-4.2z"/></svg></span><span>About</span></a></li>
+                <li><a href="services.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4.5 6.75h15v3h-15zm0 5.25h15v3h-15zm0 5.25h15v3h-15z"/></svg></span><span>Services</span></a></li>
+                <li><a href="resources.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5.25 4.5h13.5A1.5 1.5 0 0 1 20.25 6v12a1.5 1.5 0 0 1-1.5 1.5H8.25l-4.5-4.5V6a1.5 1.5 0 0 1 1.5-1.5zm3 13.5v-3h-3z"/></svg></span><span>Resources</span></a></li>
+                <li><a href="articles.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5.25 4.5h13.5v15h-13.5zm3 3v1.5h7.5V7.5zm0 3.75v1.5h7.5v-1.5zm0 3.75v1.5h5.25V15z"/></svg></span><span>Articles</span></a></li>
+                <li><a href="calculators.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 3.75h12A2.25 2.25 0 0 1 20.25 6v12A2.25 2.25 0 0 1 18 20.25H6A2.25 2.25 0 0 1 3.75 18V6A2.25 2.25 0 0 1 6 3.75zm1.5 3v3h9v-3zm0 4.5v1.5H9v-1.5zm3 0v1.5h1.5v-1.5zm3 0v1.5H15v-1.5zm-6 3v1.5H9v-1.5zm3 0v1.5h1.5v-1.5zm3 0v1.5H15v-1.5z"/></svg></span><span>Calculators</span></a></li>
+                <li><a href="workout-generator.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M2.25 9h3v6h-3zm16.5 0h3v6h-3zM6 10.5h12v3H6zm1.5-3h2.25v9H7.5zm6.75 0h2.25v9h-2.25z"/></svg></span><span>Workout Generator</span></a></li>
+                <li><a href="nutrition-calculator.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M7.5 3.75a3.75 3.75 0 0 1 3.75 3.75c0 1.6-1.01 3.05-2.45 3.57l.95 8.68H6.3l.95-8.68A3.75 3.75 0 0 1 7.5 3.75zm8.25 0c.41 0 .75.34.75.75v15.75h-1.5V12h-2.25V4.5c0-.41.34-.75.75-.75z"/></svg></span><span>Nutrition Calculator</span></a></li>
+                <li><a href="begin.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="m8.25 5.25 9 6.75-9 6.75z"/></svg></span><span>Begin</span></a></li>
         </ul>
     </nav>
 

--- a/js/main.js
+++ b/js/main.js
@@ -167,6 +167,15 @@ function calculateBMI() {
 }
 
 document.addEventListener('DOMContentLoaded', function () {
+    var siteNav = document.querySelector('.site-nav');
+    var menuToggle = document.querySelector('.site-nav__toggle');
+    if (siteNav && menuToggle) {
+        menuToggle.addEventListener('click', function () {
+            var isOpen = siteNav.classList.toggle('is-open');
+            menuToggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+        });
+    }
+
     var smolovButton = document.querySelector('#smolovCalculator');
     if (smolovButton) {
         smolovButton.addEventListener('click', smolovNumbers);

--- a/nutrition-calculator.html
+++ b/nutrition-calculator.html
@@ -270,17 +270,24 @@
 </head>
 
 <body>
-    <nav>
-        <ul>
-            <li><a href="index.html">Home</a></li>
-            <li><a href="about.html">About</a></li>
-            <li><a href="services.html">Services</a></li>
-            <li><a href="resources.html">Resources</a></li>
-            <li><a href="articles.html">Articles</a></li>
-            <li><a href="calculators.html">Calculators</a></li>
-            <li><a href="workout-generator.html">Workout Generator</a></li>
-            <li><a href="nutrition-calculator.html" aria-current="page">Nutrition Calculator</a></li>
-            <li><a href="begin.html">Begin</a></li>
+    <nav class="site-nav">
+        <a class="site-brand" href="index.html" aria-label="Matt McGinley Personal Training home">
+            <span class="site-brand__mark" aria-hidden="true">MM</span>
+            <span class="site-brand__text">Matt McGinley Personal Training</span>
+        </a>
+        <button class="site-nav__toggle" type="button" aria-expanded="false" aria-controls="site-menu" aria-label="Open navigation menu">
+            <span class="site-nav__hamburger" aria-hidden="true"></span>
+        </button>
+        <ul id="site-menu" class="site-nav__menu">
+                <li><a href="index.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 10.5 12 3l9 7.5v9a1.5 1.5 0 0 1-1.5 1.5h-5.25V14h-4.5v7H4.5A1.5 1.5 0 0 1 3 19.5z"/></svg></span><span>Home</span></a></li>
+                <li><a href="about.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 12a4.5 4.5 0 1 0-4.5-4.5A4.5 4.5 0 0 0 12 12zm0 2.25c-3.75 0-6.75 1.88-6.75 4.2V21h13.5v-2.55c0-2.32-3-4.2-6.75-4.2z"/></svg></span><span>About</span></a></li>
+                <li><a href="services.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4.5 6.75h15v3h-15zm0 5.25h15v3h-15zm0 5.25h15v3h-15z"/></svg></span><span>Services</span></a></li>
+                <li><a href="resources.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5.25 4.5h13.5A1.5 1.5 0 0 1 20.25 6v12a1.5 1.5 0 0 1-1.5 1.5H8.25l-4.5-4.5V6a1.5 1.5 0 0 1 1.5-1.5zm3 13.5v-3h-3z"/></svg></span><span>Resources</span></a></li>
+                <li><a href="articles.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5.25 4.5h13.5v15h-13.5zm3 3v1.5h7.5V7.5zm0 3.75v1.5h7.5v-1.5zm0 3.75v1.5h5.25V15z"/></svg></span><span>Articles</span></a></li>
+                <li><a href="calculators.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 3.75h12A2.25 2.25 0 0 1 20.25 6v12A2.25 2.25 0 0 1 18 20.25H6A2.25 2.25 0 0 1 3.75 18V6A2.25 2.25 0 0 1 6 3.75zm1.5 3v3h9v-3zm0 4.5v1.5H9v-1.5zm3 0v1.5h1.5v-1.5zm3 0v1.5H15v-1.5zm-6 3v1.5H9v-1.5zm3 0v1.5h1.5v-1.5zm3 0v1.5H15v-1.5z"/></svg></span><span>Calculators</span></a></li>
+                <li><a href="workout-generator.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M2.25 9h3v6h-3zm16.5 0h3v6h-3zM6 10.5h12v3H6zm1.5-3h2.25v9H7.5zm6.75 0h2.25v9h-2.25z"/></svg></span><span>Workout Generator</span></a></li>
+                <li><a href="nutrition-calculator.html" aria-current="page"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M7.5 3.75a3.75 3.75 0 0 1 3.75 3.75c0 1.6-1.01 3.05-2.45 3.57l.95 8.68H6.3l.95-8.68A3.75 3.75 0 0 1 7.5 3.75zm8.25 0c.41 0 .75.34.75.75v15.75h-1.5V12h-2.25V4.5c0-.41.34-.75.75-.75z"/></svg></span><span>Nutrition Calculator</span></a></li>
+                <li><a href="begin.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="m8.25 5.25 9 6.75-9 6.75z"/></svg></span><span>Begin</span></a></li>
         </ul>
     </nav>
     <div class="wrap">

--- a/resources.html
+++ b/resources.html
@@ -15,17 +15,24 @@
     <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
-    <nav>
-        <ul>
-            <li><a href="index.html">Home</a></li>
-            <li><a href="about.html">About</a></li>
-            <li><a href="services.html">Services</a></li>
-            <li><a href="resources.html" aria-current="page">Resources</a></li>
-            <li><a href="articles.html">Articles</a></li>
-            <li><a href="calculators.html">Calculators</a></li>
-            <li><a href="workout-generator.html">Workout Generator</a></li>
-            <li><a href="nutrition-calculator.html">Nutrition Calculator</a></li>
-            <li><a href="begin.html">Begin</a></li>
+    <nav class="site-nav">
+        <a class="site-brand" href="index.html" aria-label="Matt McGinley Personal Training home">
+            <span class="site-brand__mark" aria-hidden="true">MM</span>
+            <span class="site-brand__text">Matt McGinley Personal Training</span>
+        </a>
+        <button class="site-nav__toggle" type="button" aria-expanded="false" aria-controls="site-menu" aria-label="Open navigation menu">
+            <span class="site-nav__hamburger" aria-hidden="true"></span>
+        </button>
+        <ul id="site-menu" class="site-nav__menu">
+                <li><a href="index.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 10.5 12 3l9 7.5v9a1.5 1.5 0 0 1-1.5 1.5h-5.25V14h-4.5v7H4.5A1.5 1.5 0 0 1 3 19.5z"/></svg></span><span>Home</span></a></li>
+                <li><a href="about.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 12a4.5 4.5 0 1 0-4.5-4.5A4.5 4.5 0 0 0 12 12zm0 2.25c-3.75 0-6.75 1.88-6.75 4.2V21h13.5v-2.55c0-2.32-3-4.2-6.75-4.2z"/></svg></span><span>About</span></a></li>
+                <li><a href="services.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4.5 6.75h15v3h-15zm0 5.25h15v3h-15zm0 5.25h15v3h-15z"/></svg></span><span>Services</span></a></li>
+                <li><a href="resources.html" aria-current="page"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5.25 4.5h13.5A1.5 1.5 0 0 1 20.25 6v12a1.5 1.5 0 0 1-1.5 1.5H8.25l-4.5-4.5V6a1.5 1.5 0 0 1 1.5-1.5zm3 13.5v-3h-3z"/></svg></span><span>Resources</span></a></li>
+                <li><a href="articles.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5.25 4.5h13.5v15h-13.5zm3 3v1.5h7.5V7.5zm0 3.75v1.5h7.5v-1.5zm0 3.75v1.5h5.25V15z"/></svg></span><span>Articles</span></a></li>
+                <li><a href="calculators.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 3.75h12A2.25 2.25 0 0 1 20.25 6v12A2.25 2.25 0 0 1 18 20.25H6A2.25 2.25 0 0 1 3.75 18V6A2.25 2.25 0 0 1 6 3.75zm1.5 3v3h9v-3zm0 4.5v1.5H9v-1.5zm3 0v1.5h1.5v-1.5zm3 0v1.5H15v-1.5zm-6 3v1.5H9v-1.5zm3 0v1.5h1.5v-1.5zm3 0v1.5H15v-1.5z"/></svg></span><span>Calculators</span></a></li>
+                <li><a href="workout-generator.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M2.25 9h3v6h-3zm16.5 0h3v6h-3zM6 10.5h12v3H6zm1.5-3h2.25v9H7.5zm6.75 0h2.25v9h-2.25z"/></svg></span><span>Workout Generator</span></a></li>
+                <li><a href="nutrition-calculator.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M7.5 3.75a3.75 3.75 0 0 1 3.75 3.75c0 1.6-1.01 3.05-2.45 3.57l.95 8.68H6.3l.95-8.68A3.75 3.75 0 0 1 7.5 3.75zm8.25 0c.41 0 .75.34.75.75v15.75h-1.5V12h-2.25V4.5c0-.41.34-.75.75-.75z"/></svg></span><span>Nutrition Calculator</span></a></li>
+                <li><a href="begin.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="m8.25 5.25 9 6.75-9 6.75z"/></svg></span><span>Begin</span></a></li>
         </ul>
     </nav>
     <header class="hero">

--- a/services.html
+++ b/services.html
@@ -14,17 +14,24 @@
 </head>
 
 <body>
-    <nav>
-        <ul>
-            <li><a href="index.html">Home</a></li>
-            <li><a href="about.html">About</a></li>
-            <li><a href="services.html" aria-current="page">Services</a></li>
-            <li><a href="resources.html">Resources</a></li>
-            <li><a href="articles.html">Articles</a></li>
-            <li><a href="calculators.html">Calculators</a></li>
-            <li><a href="workout-generator.html">Workout Generator</a></li>
-            <li><a href="nutrition-calculator.html">Nutrition Calculator</a></li>
-            <li><a href="begin.html">Begin</a></li>
+    <nav class="site-nav">
+        <a class="site-brand" href="index.html" aria-label="Matt McGinley Personal Training home">
+            <span class="site-brand__mark" aria-hidden="true">MM</span>
+            <span class="site-brand__text">Matt McGinley Personal Training</span>
+        </a>
+        <button class="site-nav__toggle" type="button" aria-expanded="false" aria-controls="site-menu" aria-label="Open navigation menu">
+            <span class="site-nav__hamburger" aria-hidden="true"></span>
+        </button>
+        <ul id="site-menu" class="site-nav__menu">
+                <li><a href="index.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 10.5 12 3l9 7.5v9a1.5 1.5 0 0 1-1.5 1.5h-5.25V14h-4.5v7H4.5A1.5 1.5 0 0 1 3 19.5z"/></svg></span><span>Home</span></a></li>
+                <li><a href="about.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 12a4.5 4.5 0 1 0-4.5-4.5A4.5 4.5 0 0 0 12 12zm0 2.25c-3.75 0-6.75 1.88-6.75 4.2V21h13.5v-2.55c0-2.32-3-4.2-6.75-4.2z"/></svg></span><span>About</span></a></li>
+                <li><a href="services.html" aria-current="page"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4.5 6.75h15v3h-15zm0 5.25h15v3h-15zm0 5.25h15v3h-15z"/></svg></span><span>Services</span></a></li>
+                <li><a href="resources.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5.25 4.5h13.5A1.5 1.5 0 0 1 20.25 6v12a1.5 1.5 0 0 1-1.5 1.5H8.25l-4.5-4.5V6a1.5 1.5 0 0 1 1.5-1.5zm3 13.5v-3h-3z"/></svg></span><span>Resources</span></a></li>
+                <li><a href="articles.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5.25 4.5h13.5v15h-13.5zm3 3v1.5h7.5V7.5zm0 3.75v1.5h7.5v-1.5zm0 3.75v1.5h5.25V15z"/></svg></span><span>Articles</span></a></li>
+                <li><a href="calculators.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 3.75h12A2.25 2.25 0 0 1 20.25 6v12A2.25 2.25 0 0 1 18 20.25H6A2.25 2.25 0 0 1 3.75 18V6A2.25 2.25 0 0 1 6 3.75zm1.5 3v3h9v-3zm0 4.5v1.5H9v-1.5zm3 0v1.5h1.5v-1.5zm3 0v1.5H15v-1.5zm-6 3v1.5H9v-1.5zm3 0v1.5h1.5v-1.5zm3 0v1.5H15v-1.5z"/></svg></span><span>Calculators</span></a></li>
+                <li><a href="workout-generator.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M2.25 9h3v6h-3zm16.5 0h3v6h-3zM6 10.5h12v3H6zm1.5-3h2.25v9H7.5zm6.75 0h2.25v9h-2.25z"/></svg></span><span>Workout Generator</span></a></li>
+                <li><a href="nutrition-calculator.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M7.5 3.75a3.75 3.75 0 0 1 3.75 3.75c0 1.6-1.01 3.05-2.45 3.57l.95 8.68H6.3l.95-8.68A3.75 3.75 0 0 1 7.5 3.75zm8.25 0c.41 0 .75.34.75.75v15.75h-1.5V12h-2.25V4.5c0-.41.34-.75.75-.75z"/></svg></span><span>Nutrition Calculator</span></a></li>
+                <li><a href="begin.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="m8.25 5.25 9 6.75-9 6.75z"/></svg></span><span>Begin</span></a></li>
         </ul>
     </nav>
     <header class="hero">

--- a/workout-generator.html
+++ b/workout-generator.html
@@ -11,17 +11,24 @@
     <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
-    <nav>
-        <ul>
-            <li><a href="index.html">Home</a></li>
-            <li><a href="about.html">About</a></li>
-            <li><a href="services.html">Services</a></li>
-            <li><a href="resources.html">Resources</a></li>
-            <li><a href="articles.html">Articles</a></li>
-            <li><a href="calculators.html">Calculators</a></li>
-            <li><a href="workout-generator.html" aria-current="page">Workout Generator</a></li>
-            <li><a href="nutrition-calculator.html">Nutrition Calculator</a></li>
-            <li><a href="begin.html">Begin</a></li>
+    <nav class="site-nav">
+        <a class="site-brand" href="index.html" aria-label="Matt McGinley Personal Training home">
+            <span class="site-brand__mark" aria-hidden="true">MM</span>
+            <span class="site-brand__text">Matt McGinley Personal Training</span>
+        </a>
+        <button class="site-nav__toggle" type="button" aria-expanded="false" aria-controls="site-menu" aria-label="Open navigation menu">
+            <span class="site-nav__hamburger" aria-hidden="true"></span>
+        </button>
+        <ul id="site-menu" class="site-nav__menu">
+                <li><a href="index.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 10.5 12 3l9 7.5v9a1.5 1.5 0 0 1-1.5 1.5h-5.25V14h-4.5v7H4.5A1.5 1.5 0 0 1 3 19.5z"/></svg></span><span>Home</span></a></li>
+                <li><a href="about.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 12a4.5 4.5 0 1 0-4.5-4.5A4.5 4.5 0 0 0 12 12zm0 2.25c-3.75 0-6.75 1.88-6.75 4.2V21h13.5v-2.55c0-2.32-3-4.2-6.75-4.2z"/></svg></span><span>About</span></a></li>
+                <li><a href="services.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4.5 6.75h15v3h-15zm0 5.25h15v3h-15zm0 5.25h15v3h-15z"/></svg></span><span>Services</span></a></li>
+                <li><a href="resources.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5.25 4.5h13.5A1.5 1.5 0 0 1 20.25 6v12a1.5 1.5 0 0 1-1.5 1.5H8.25l-4.5-4.5V6a1.5 1.5 0 0 1 1.5-1.5zm3 13.5v-3h-3z"/></svg></span><span>Resources</span></a></li>
+                <li><a href="articles.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5.25 4.5h13.5v15h-13.5zm3 3v1.5h7.5V7.5zm0 3.75v1.5h7.5v-1.5zm0 3.75v1.5h5.25V15z"/></svg></span><span>Articles</span></a></li>
+                <li><a href="calculators.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 3.75h12A2.25 2.25 0 0 1 20.25 6v12A2.25 2.25 0 0 1 18 20.25H6A2.25 2.25 0 0 1 3.75 18V6A2.25 2.25 0 0 1 6 3.75zm1.5 3v3h9v-3zm0 4.5v1.5H9v-1.5zm3 0v1.5h1.5v-1.5zm3 0v1.5H15v-1.5zm-6 3v1.5H9v-1.5zm3 0v1.5h1.5v-1.5zm3 0v1.5H15v-1.5z"/></svg></span><span>Calculators</span></a></li>
+                <li><a href="workout-generator.html" aria-current="page"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M2.25 9h3v6h-3zm16.5 0h3v6h-3zM6 10.5h12v3H6zm1.5-3h2.25v9H7.5zm6.75 0h2.25v9h-2.25z"/></svg></span><span>Workout Generator</span></a></li>
+                <li><a href="nutrition-calculator.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M7.5 3.75a3.75 3.75 0 0 1 3.75 3.75c0 1.6-1.01 3.05-2.45 3.57l.95 8.68H6.3l.95-8.68A3.75 3.75 0 0 1 7.5 3.75zm8.25 0c.41 0 .75.34.75.75v15.75h-1.5V12h-2.25V4.5c0-.41.34-.75.75-.75z"/></svg></span><span>Nutrition Calculator</span></a></li>
+                <li><a href="begin.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="m8.25 5.25 9 6.75-9 6.75z"/></svg></span><span>Begin</span></a></li>
         </ul>
     </nav>
 


### PR DESCRIPTION
### Motivation
- Replace the existing left-to-right sliding tab navigation with a compact, consistent global header to improve visual hierarchy and make the site feel more like a personal brand.
- Provide a compact mobile-friendly control (hamburger) that reveals the full set of existing links so no page wording or content is removed.

### Description
- Replaced the old `<nav>` on all primary pages with a shared branded header structure containing a left `MM` mark + `Matt McGinley Personal Training` brand and a right-side hamburger button that opens a dropdown menu (updated files: `index.html`, `about.html`, `services.html`, `resources.html`, `articles.html`, `calculators.html`, `workout-generator.html`, `nutrition-calculator.html`, `begin.html`).
- Preserved every existing nav label and `aria-current` states while inserting small minimalist white SVG icons next to each label inside the dropdown menu.
- Added new styles in `css/style.css` for `.site-nav`, `.site-brand`, hamburger control, dropdown panel, and icon treatment to match the existing color system and be responsive.
- Added a small JS toggle in `js/main.js` that updates `aria-expanded` and toggles `.is-open` on the nav to open/close the dropdown (`menuToggle` click handler).

### Testing
- Ran repository and file discovery with `rg --files` and inspected page nav occurrences with `rg -n "<nav" *.html`, which returned the expected pages and succeeded.
- Verified the new `site-nav` usage with `rg -n "site-nav" *.html css/style.css js/main.js` and inspected changed blocks with `sed`/file reads to confirm markup and CSS additions, all succeeded.
- Checked working tree with `git status --short` to confirm the intended files were modified, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3ed8242548326878e3b9845d102fb)