### PR TITLE
Refine mobile hero header brand lockup and eyebrow treatment

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -130,17 +130,54 @@ section {
 
 .hero__eyebrow {
     display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    padding: 0.45rem 0.85rem;
-    border-radius: 999px;
-    background: rgba(255, 107, 8, 0.16);
-    border: 1px solid rgba(255, 107, 8, 0.35);
-    color: #ffd6be;
+    align-items: flex-start;
+    gap: 0.5rem;
+    margin: 0;
+    max-width: min(100%, 34rem);
+    color: #ffab73;
     font-weight: 700;
-    font-size: 0.82rem;
+    font-size: 0.74rem;
     text-transform: uppercase;
-    letter-spacing: 0.12em;
+    letter-spacing: 0.13em;
+}
+
+.eyebrow-icon {
+    width: 18px;
+    height: 10px;
+    margin-top: 0.28rem;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 124, 51, 0.75);
+    box-shadow: 0 0 10px rgba(255, 124, 51, 0.45);
+    position: relative;
+    flex-shrink: 0;
+}
+
+.eyebrow-icon::before,
+.eyebrow-icon::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    width: 2px;
+    height: 12px;
+    border-radius: 999px;
+    background: rgba(255, 124, 51, 0.88);
+    transform: translateY(-50%);
+}
+
+.eyebrow-icon::before { left: -4px; }
+.eyebrow-icon::after { right: -4px; }
+
+.eyebrow-divider {
+    width: 1px;
+    min-height: 1.5em;
+    background: rgba(255, 171, 115, 0.75);
+    margin-top: 0.05rem;
+    flex-shrink: 0;
+}
+
+.hero-eyebrow {
+    line-height: 1.45;
+    overflow-wrap: anywhere;
 }
 
 .hero-trust {
@@ -949,31 +986,40 @@ nav a:hover {
     position: sticky;
 }
 
-.site-brand {
+.site-brand,
+.brand-lockup {
     display: inline-flex;
     align-items: center;
-    gap: 0.65rem;
+    gap: 0.7rem;
     text-decoration: none;
     color: #fff;
 }
 
-.site-brand__mark {
-    width: 2.2rem;
-    height: 2.2rem;
-    border: 1px solid rgba(255, 255, 255, 0.55);
+.site-brand__mark,
+.brand-mark {
+    width: clamp(52px, 15vw, 64px);
+    aspect-ratio: 1 / 1;
+    border: 1px solid rgba(255, 255, 255, 0.36);
     border-radius: 999px;
+    background: rgba(7, 19, 44, 0.68);
+    box-shadow: 0 0 0 1px rgba(255, 124, 51, 0.2), 0 0 18px rgba(255, 124, 51, 0.34);
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    font-weight: 700;
-    font-size: 0.85rem;
-    letter-spacing: 0.04em;
+    font-weight: 800;
+    font-size: clamp(0.88rem, 2.9vw, 1rem);
+    letter-spacing: 0.03em;
+    color: #fff;
+    flex-shrink: 0;
 }
 
-.site-brand__text {
-    font-size: 0.95rem;
-    font-weight: 600;
-    line-height: 1.2;
+.site-brand__text,
+.brand-wordmark {
+    font-size: clamp(0.98rem, 3.1vw, 1.08rem);
+    font-weight: 700;
+    line-height: 1.15;
+    letter-spacing: 0.015em;
+    color: #fff;
 }
 
 .site-nav__toggle {
@@ -1046,6 +1092,18 @@ nav a:hover {
 
 @media (min-width: 900px) {
     .site-brand__text { font-size: 1rem; }
+}
+
+
+@media (max-width: 420px) {
+    .hero__eyebrow {
+        align-items: center;
+    }
+
+    .eyebrow-divider {
+        align-self: stretch;
+        min-height: 2.2em;
+    }
 }
 
 @media (min-width: 768px) {
@@ -1695,11 +1753,6 @@ section,
     border-bottom: 1px solid rgba(129, 165, 210, 0.26);
 }
 
-.hero__eyebrow {
-    background: rgba(255, 106, 26, 0.15);
-    border-color: rgba(255, 106, 26, 0.38);
-    color: #ffc49c;
-}
 
 .tagline,
 .subheading,

--- a/index.html
+++ b/index.html
@@ -16,9 +16,9 @@
 
 <body>
     <nav class="site-nav">
-        <a class="site-brand" href="index.html" aria-label="Matt McGinley Personal Training home">
-            <span class="site-brand__mark" aria-hidden="true">MM</span>
-            <span class="site-brand__text">Matt McGinley Personal Training</span>
+        <a class="site-brand brand-lockup" href="index.html" aria-label="Matt McGinley Personal Training home">
+            <span class="site-brand__mark brand-mark" aria-hidden="true">MM</span>
+            <span class="site-brand__text brand-wordmark">Matt McGinley Training</span>
         </a>
         <button class="site-nav__toggle" type="button" aria-expanded="false" aria-controls="site-menu" aria-label="Open navigation menu">
             <span class="site-nav__hamburger" aria-hidden="true"></span>
@@ -39,7 +39,11 @@
     <header class="hero">
         <div class="hero__content">
             <div class="hero__copy">
-                <p class="hero__eyebrow">Online strength + body composition coaching</p>
+                <p class="hero__eyebrow">
+                    <span class="eyebrow-icon" aria-hidden="true"></span>
+                    <span class="eyebrow-divider" aria-hidden="true"></span>
+                    <span class="hero-eyebrow">Online strength + body composition coaching</span>
+                </p>
                 <h1>A direct, simple training program for real people</h1>
                 <p class="tagline">I have the plan to get you all the results you want. You just need to show up.</p>
                 <div class="hero-actions">


### PR DESCRIPTION
### Motivation
- Improve the mobile header and hero eyebrow visual so the brand and category label read as a cleaner, more premium lockup rather than boxed pills. 
- Preserve all existing content, headline copy, CTAs, navigation behavior, and the current dark navy/orange palette while removing bulky rounded containers. 

### Description
- Updated homepage markup in `index.html` to replace the pill-wrapped brand and eyebrow with a horizontal brand lockup (`brand-lockup`, `brand-mark`, `brand-wordmark`) and an inline eyebrow structure (`eyebrow-icon`, `eyebrow-divider`, `hero-eyebrow`).
- Replaced the visible wordmark text to the shortened clean form `Matt McGinley Training` and kept the `MM` monogram as a standalone circular badge sized with `clamp(52px, 15vw, 64px)` for mobile balance.
- Removed the orange rounded pill background for the eyebrow and implemented a slim inline treatment (small orange decorative mark, vertical divider, uppercase orange label) with controlled wrapping using `overflow-wrap` and a mobile `@media (max-width: 420px)` tweak.
- Kept all other layout, copy, CTAs, hero gradient background, and color tokens unchanged while scoping new styles into reusable classes named in the guidance.

### Testing
- Ran `git status --short` to confirm working-tree changes were present and visible, which completed successfully. 
- Attempted an automated mobile screenshot using Playwright to verify the visual output, but the run failed because Playwright is not installed in the environment. 
- Manual diff inspection and file checks were performed on `index.html` and `css/style.css` to verify the markup and style changes applied as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f90c4fb4b88326b7d3faef85fda575)