### PR TITLE
Polish header brand lockup and replace homepage pill badge with premium label

### DIFF
--- a/about.html
+++ b/about.html
@@ -16,8 +16,11 @@
 <body>
     <nav class="site-nav">
         <a class="site-brand" href="index.html" aria-label="Matt McGinley Personal Training home">
-            <span class="site-brand__mark" aria-hidden="true">MM</span>
-            <span class="site-brand__text">Matt McGinley Personal Training</span>
+            <span class="site-brand__mark" aria-hidden="true"><span>MM</span></span>
+            <span class="site-brand__text">
+                <span class="site-brand__name">Matt McGinley</span>
+                <span class="site-brand__subtitle">Training</span>
+            </span>
         </a>
         <button class="site-nav__toggle" type="button" aria-expanded="false" aria-controls="site-menu" aria-label="Open navigation menu">
             <span class="site-nav__hamburger" aria-hidden="true"></span>

--- a/articles.html
+++ b/articles.html
@@ -17,8 +17,11 @@
 <body>
     <nav class="site-nav">
         <a class="site-brand" href="index.html" aria-label="Matt McGinley Personal Training home">
-            <span class="site-brand__mark" aria-hidden="true">MM</span>
-            <span class="site-brand__text">Matt McGinley Personal Training</span>
+            <span class="site-brand__mark" aria-hidden="true"><span>MM</span></span>
+            <span class="site-brand__text">
+                <span class="site-brand__name">Matt McGinley</span>
+                <span class="site-brand__subtitle">Training</span>
+            </span>
         </a>
         <button class="site-nav__toggle" type="button" aria-expanded="false" aria-controls="site-menu" aria-label="Open navigation menu">
             <span class="site-nav__hamburger" aria-hidden="true"></span>

--- a/begin.html
+++ b/begin.html
@@ -16,8 +16,11 @@
 <body>
     <nav class="site-nav">
         <a class="site-brand" href="index.html" aria-label="Matt McGinley Personal Training home">
-            <span class="site-brand__mark" aria-hidden="true">MM</span>
-            <span class="site-brand__text">Matt McGinley Personal Training</span>
+            <span class="site-brand__mark" aria-hidden="true"><span>MM</span></span>
+            <span class="site-brand__text">
+                <span class="site-brand__name">Matt McGinley</span>
+                <span class="site-brand__subtitle">Training</span>
+            </span>
         </a>
         <button class="site-nav__toggle" type="button" aria-expanded="false" aria-controls="site-menu" aria-label="Open navigation menu">
             <span class="site-nav__hamburger" aria-hidden="true"></span>

--- a/calculators.html
+++ b/calculators.html
@@ -16,8 +16,11 @@
 <body>
     <nav class="site-nav">
         <a class="site-brand" href="index.html" aria-label="Matt McGinley Personal Training home">
-            <span class="site-brand__mark" aria-hidden="true">MM</span>
-            <span class="site-brand__text">Matt McGinley Personal Training</span>
+            <span class="site-brand__mark" aria-hidden="true"><span>MM</span></span>
+            <span class="site-brand__text">
+                <span class="site-brand__name">Matt McGinley</span>
+                <span class="site-brand__subtitle">Training</span>
+            </span>
         </a>
         <button class="site-nav__toggle" type="button" aria-expanded="false" aria-controls="site-menu" aria-label="Open navigation menu">
             <span class="site-nav__hamburger" aria-hidden="true"></span>

--- a/css/style.css
+++ b/css/style.css
@@ -129,18 +129,21 @@ section {
 }
 
 .hero__eyebrow {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    padding: 0.45rem 0.85rem;
-    border-radius: 999px;
+    display: inline-grid;
+    justify-items: start;
+    gap: 0.25rem;
+    padding: 0.65rem 0.85rem 0.65rem 0.95rem;
+    border-radius: 10px;
     background: rgba(255, 107, 8, 0.16);
     border: 1px solid rgba(255, 107, 8, 0.35);
+    border-left: 3px solid rgba(255, 107, 8, 0.9);
     color: #ffd6be;
     font-weight: 700;
-    font-size: 0.82rem;
+    font-size: 0.76rem;
     text-transform: uppercase;
-    letter-spacing: 0.12em;
+    letter-spacing: 0.18em;
+    max-width: 34ch;
+    text-align: left;
 }
 
 .hero-trust {
@@ -952,28 +955,73 @@ nav a:hover {
 .site-brand {
     display: inline-flex;
     align-items: center;
-    gap: 0.65rem;
+    gap: 0.75rem;
     text-decoration: none;
     color: #fff;
+    min-width: 0;
 }
 
 .site-brand__mark {
-    width: 2.2rem;
-    height: 2.2rem;
-    border: 1px solid rgba(255, 255, 255, 0.55);
-    border-radius: 999px;
+    width: 2.25rem;
+    height: 2.25rem;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    font-weight: 700;
-    font-size: 0.85rem;
-    letter-spacing: 0.04em;
+    font-weight: 800;
+    font-size: 0.82rem;
+    letter-spacing: 0.13em;
+    border-right: 1px solid rgba(255, 255, 255, 0.35);
+    padding-right: 0.75rem;
+    flex-shrink: 0;
 }
 
 .site-brand__text {
-    font-size: 0.95rem;
-    font-weight: 600;
-    line-height: 1.2;
+    display: grid;
+    gap: 0.05rem;
+    line-height: 1.05;
+    min-width: 0;
+}
+
+.site-brand__mark span {
+    line-height: 1;
+    position: relative;
+}
+
+.site-brand__mark span::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    bottom: -0.18rem;
+    width: 100%;
+    height: 2px;
+    background: rgba(255, 106, 26, 0.9);
+    border-radius: 999px;
+}
+
+.site-brand__name {
+    font-size: 0.93rem;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    color: #f8fbff;
+}
+
+.site-brand__subtitle {
+    font-size: 0.7rem;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.26em;
+    color: rgba(228, 239, 255, 0.78);
+}
+
+@media (max-width: 520px) {
+    .site-brand__name {
+        font-size: 0.84rem;
+    }
+
+    .site-brand__subtitle {
+        font-size: 0.62rem;
+        letter-spacing: 0.2em;
+    }
 }
 
 .site-nav__toggle {
@@ -1045,7 +1093,7 @@ nav a:hover {
 }
 
 @media (min-width: 900px) {
-    .site-brand__text { font-size: 1rem; }
+    .site-brand__name { font-size: 1rem; }
 }
 
 @media (min-width: 768px) {

--- a/index.html
+++ b/index.html
@@ -17,8 +17,11 @@
 <body>
     <nav class="site-nav">
         <a class="site-brand" href="index.html" aria-label="Matt McGinley Personal Training home">
-            <span class="site-brand__mark" aria-hidden="true">MM</span>
-            <span class="site-brand__text">Matt McGinley Personal Training</span>
+            <span class="site-brand__mark" aria-hidden="true"><span>MM</span></span>
+            <span class="site-brand__text">
+                <span class="site-brand__name">Matt McGinley</span>
+                <span class="site-brand__subtitle">Training</span>
+            </span>
         </a>
         <button class="site-nav__toggle" type="button" aria-expanded="false" aria-controls="site-menu" aria-label="Open navigation menu">
             <span class="site-nav__hamburger" aria-hidden="true"></span>

--- a/nutrition-calculator.html
+++ b/nutrition-calculator.html
@@ -272,8 +272,11 @@
 <body>
     <nav class="site-nav">
         <a class="site-brand" href="index.html" aria-label="Matt McGinley Personal Training home">
-            <span class="site-brand__mark" aria-hidden="true">MM</span>
-            <span class="site-brand__text">Matt McGinley Personal Training</span>
+            <span class="site-brand__mark" aria-hidden="true"><span>MM</span></span>
+            <span class="site-brand__text">
+                <span class="site-brand__name">Matt McGinley</span>
+                <span class="site-brand__subtitle">Training</span>
+            </span>
         </a>
         <button class="site-nav__toggle" type="button" aria-expanded="false" aria-controls="site-menu" aria-label="Open navigation menu">
             <span class="site-nav__hamburger" aria-hidden="true"></span>

--- a/resources.html
+++ b/resources.html
@@ -17,8 +17,11 @@
 <body>
     <nav class="site-nav">
         <a class="site-brand" href="index.html" aria-label="Matt McGinley Personal Training home">
-            <span class="site-brand__mark" aria-hidden="true">MM</span>
-            <span class="site-brand__text">Matt McGinley Personal Training</span>
+            <span class="site-brand__mark" aria-hidden="true"><span>MM</span></span>
+            <span class="site-brand__text">
+                <span class="site-brand__name">Matt McGinley</span>
+                <span class="site-brand__subtitle">Training</span>
+            </span>
         </a>
         <button class="site-nav__toggle" type="button" aria-expanded="false" aria-controls="site-menu" aria-label="Open navigation menu">
             <span class="site-nav__hamburger" aria-hidden="true"></span>

--- a/services.html
+++ b/services.html
@@ -16,8 +16,11 @@
 <body>
     <nav class="site-nav">
         <a class="site-brand" href="index.html" aria-label="Matt McGinley Personal Training home">
-            <span class="site-brand__mark" aria-hidden="true">MM</span>
-            <span class="site-brand__text">Matt McGinley Personal Training</span>
+            <span class="site-brand__mark" aria-hidden="true"><span>MM</span></span>
+            <span class="site-brand__text">
+                <span class="site-brand__name">Matt McGinley</span>
+                <span class="site-brand__subtitle">Training</span>
+            </span>
         </a>
         <button class="site-nav__toggle" type="button" aria-expanded="false" aria-controls="site-menu" aria-label="Open navigation menu">
             <span class="site-nav__hamburger" aria-hidden="true"></span>

--- a/workout-generator.html
+++ b/workout-generator.html
@@ -13,8 +13,11 @@
 <body>
     <nav class="site-nav">
         <a class="site-brand" href="index.html" aria-label="Matt McGinley Personal Training home">
-            <span class="site-brand__mark" aria-hidden="true">MM</span>
-            <span class="site-brand__text">Matt McGinley Personal Training</span>
+            <span class="site-brand__mark" aria-hidden="true"><span>MM</span></span>
+            <span class="site-brand__text">
+                <span class="site-brand__name">Matt McGinley</span>
+                <span class="site-brand__subtitle">Training</span>
+            </span>
         </a>
         <button class="site-nav__toggle" type="button" aria-expanded="false" aria-controls="site-menu" aria-label="Open navigation menu">
             <span class="site-nav__hamburger" aria-hidden="true"></span>


### PR DESCRIPTION
### Motivation
- Remove the pill/capsule/bubble appearance from the global top-left brand and the homepage eyebrow badge while keeping all site structure, links, and functionality unchanged. 
- Provide a clean, professional text-based logo lockup with a compact `MM` monogram and a two-line name (`Matt McGinley` / `Training`) that reads well on desktop and mobile. 

### Description
- Replaced the header brand markup across all pages to a text lockup using `MM` monogram plus `site-brand__name` and `site-brand__subtitle` spans in each nav instance (updated multiple HTML files including `index.html`, `services.html`, `about.html`, `articles.html`, `calculators.html`, `resources.html`, `begin.html`, `workout-generator.html`, and `nutrition-calculator.html`).
- Updated `css/style.css` to remove the circular/pill badge styling from `.site-brand__mark` and `.site-brand__text` and instead apply a divider, tightened type, subtle orange underline accent, and compact spacing to produce a premium lockup that remains clickable and compact in the nav. 
- Reworked the homepage eyebrow `.hero__eyebrow` styling from a pill/capsule to a compact label/card with a subtle border, a left orange accent line, disciplined uppercase typography, and responsive sizing so it no longer looks like a button. 
- Kept all content, routing, JavaScript, nav behavior, and page sections intact and applied mobile-specific sizing rules so the brand does not crowd the menu toggle.

### Testing
- Ran repository search to confirm updated brand markup references with `rg -n "site-brand__name|site-brand__subtitle|site-brand__text" *.html css/style.css` and verified occurrences in the expected files. 
- Inspected the modified CSS blocks with `nl -ba css/style.css | sed -n '124,150p;952,1030p;1096,1097p;1694,1705p'` to confirm the new `.site-brand` and `.hero__eyebrow` rules are present. 
- Performed smoke validation by opening representative pages in the repo (file previews) to confirm the top-left lockup and homepage eyebrow text now use the new markup and styling. 
- All automated search and file-inspection checks passed and show the pill/bubble badge styling removed from the header and the homepage eyebrow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f90d8f57e08326a0b61340f9249ea2)