### PR TITLE
Fix clipping in Articles “Jump to an Article” list

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1198,6 +1198,10 @@ article ul {
     margin: 0;
     padding: 0;
     display: block;
+    background: transparent;
+    border: none;
+    border-radius: 0;
+    gap: 0;
 }
 
 .article-nav__toggle {


### PR DESCRIPTION
### Motivation
- Prevent the global rounded `nav ul` capsule styling from being applied to the Articles page jump panel so article links are not visually clipped by a circular appearance.

### Description
- Reset `.article-nav ul` in `css/style.css` by adding `background: transparent;`, `border: none;`, `border-radius: 0;`, and `gap: 0;` so the jump list no longer inherits the global nav pill styling and links display clearly inside the panel.

### Testing
- Ran the automated replacement script that updated `css/style.css` and inspected the file to confirm the new properties are present and the list no longer inherits the global navigation pill styles, and the verification succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f90edbddd08326a3d3170537a81050)