### PR TITLE
Articles: image-first card grid with featured spotlight and topic filters

### DIFF
--- a/articles.html
+++ b/articles.html
@@ -47,11 +47,11 @@
     <section class="article-section">
         <section class="blog-discovery" aria-labelledby="blogDiscoveryHeading">
             <div class="blog-discovery__intro">
-                <h2 id="blogDiscoveryHeading">Start here</h2>
-                <p>New to lifting and nutrition? Start with these 3 must-read beginner pieces, then browse by topic.</p>
+                <h2 id="blogDiscoveryHeading">Featured article</h2>
+                <p>Latest coaching insight from Matt.</p>
             </div>
-            <div class="start-here-grid" id="startHereGrid">
-                <p class="article-nav__empty">Loading must-read articles…</p>
+            <div class="featured-article-spotlight" id="featuredArticleSpotlight">
+                <p class="article-nav__empty">Loading featured article…</p>
             </div>
             <div class="blog-filters" aria-label="Filter articles by topic">
                 <h3>Browse by topic</h3>

--- a/css/style.css
+++ b/css/style.css
@@ -1352,121 +1352,69 @@ article ul {
 }
 
 .blog-discovery {
-    background: var(--surface-color);
+    background: transparent;
+    border: 0;
+    border-radius: 0;
+    padding: 0;
+    margin-bottom: 1.2rem;
+}
+
+.featured-article-spotlight { margin-top: 0.9rem; }
+
+.featured-article-card,
+.article-card__link {
+    display: block;
+    text-decoration: none;
+    color: inherit;
+}
+
+.featured-article-card {
     border: 1px solid var(--border-color);
     border-radius: 12px;
-    padding: 1.25rem;
-    margin-bottom: 1.5rem;
+    overflow: hidden;
+    background: #fff;
 }
 
-.blog-discovery__intro h2 {
-    margin: 0;
-}
+.featured-article-card img { width: 100%; aspect-ratio: 16/9; object-fit: cover; display:block; }
+.featured-article-card__content { padding: 0.9rem 1rem 1rem; }
+.featured-article-card h3 { margin: 0.4rem 0 0; font-size: 1.2rem; }
 
-.start-here-grid,
 .article-discovery-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: 0.9rem;
-    margin-top: 0.85rem;
-}
-
-.start-here-card,
-.article-card {
-    border: 1px solid var(--border-color);
-    border-radius: 10px;
-    padding: 0.85rem;
-    background: #fff;
-    box-shadow: 0 2px 8px rgba(15, 23, 42, 0.06);
-}
-
-.article-card__meta {
-    margin: 0;
-    font-family: 'Open Sans', Arial, sans-serif;
-    font-size: 0.84rem;
-    color: #475569;
-    font-weight: 700;
-}
-
-.start-here-card h3,
-.article-card h3 {
-    margin: 0.45rem 0;
-    line-height: 1.35;
-    font-size: 1rem;
-}
-
-.start-here-card p,
-.article-card p {
-    margin: 0.2rem 0;
-    font-size: 0.95rem;
-}
-
-.blog-filters {
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 1rem;
     margin-top: 1rem;
 }
 
-.blog-filters h3 {
-    margin: 0;
-    font-size: 1rem;
-}
+.article-card { border: 1px solid var(--border-color); border-radius: 10px; overflow: hidden; background:#fff; }
+.article-card__image-wrap img { width:100%; aspect-ratio: 4/3; object-fit: cover; display:block; }
+.article-card__body { padding: 0.75rem 0.85rem 0.9rem; }
+.article-card h3 { margin: 0; font-size: 1rem; line-height: 1.35; }
 
-.blog-filters__buttons {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.45rem;
-    margin-top: 0.65rem;
-}
+.article-card__meta { margin: 0.45rem 0 0; font-family: 'Open Sans', Arial, sans-serif; font-size: 0.82rem; color: #475569; font-weight: 700; }
 
-.blog-filter {
-    border: 1px solid var(--border-color);
-    background: #fff;
-    color: var(--primary-color);
-    border-radius: 999px;
-    padding: 0.3rem 0.8rem;
-    font-weight: 700;
-    cursor: pointer;
-}
+.blog-filters { margin-top: 1rem; }
+.blog-filters h3 { margin: 0; font-size: 0.95rem; }
+.blog-filters__buttons { display:flex; flex-wrap:wrap; gap:0.5rem; margin-top:0.6rem; }
+.blog-filter { border: 1px solid var(--border-color); background: #fff; color: var(--primary-color); border-radius: 8px; padding: 0.3rem 0.65rem; font-weight: 700; cursor: pointer; }
+.blog-filter.is-active { background: rgba(20, 184, 166, 0.15); border-color: var(--primary-color); color: #0f172a; }
 
-.blog-filter.is-active {
-    background: rgba(20, 184, 166, 0.15);
-    border-color: var(--primary-color);
-    color: #0f172a;
-}
-
-.article-section article {
+.article-section article[id] {
     padding: 1rem 1.5rem;
     background: var(--surface-color);
     border-radius: 8px;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
-    margin-bottom: 2rem;
+    margin: 2rem 0;
     border: 1px solid var(--border-color);
     font-family: 'Merriweather', serif;
     line-height: 1.75;
     scroll-margin-top: 1rem;
 }
 
-.article-section article:last-child {
-    margin-bottom: 0;
+@media (max-width: 760px) {
+    .article-discovery-grid { grid-template-columns: 1fr; gap: 0.8rem; }
+    .featured-article-card h3 { font-size: 1.05rem; }
 }
-
-.article-section article p {
-    margin: 0.75em 0;
-    font-size: 1.05em;
-}
-
-.article-meta {
-    font-family: 'Open Sans', Arial, sans-serif;
-    color: #475569;
-    font-size: 0.9rem;
-    font-weight: 700;
-    margin: 0.25rem 0 0.6rem;
-}
-
-.article-excerpt {
-    font-size: 1.05rem;
-    color: #334155;
-}
-
 /* Calculator card styling */
 .calculator-section {
     padding: 0;

--- a/css/style.css
+++ b/css/style.css
@@ -1375,7 +1375,7 @@ article ul {
     background: #fff;
 }
 
-.featured-article-card img { width: 100%; aspect-ratio: 16/9; object-fit: cover; display:block; }
+.featured-article-card img { width: 100%; aspect-ratio: 16/9; object-fit: contain; display:block; background: #f8fafc; }
 .featured-article-card__content { padding: 0.9rem 1rem 1rem; }
 .featured-article-card h3 { margin: 0.4rem 0 0; font-size: 1.2rem; }
 
@@ -1387,7 +1387,7 @@ article ul {
 }
 
 .article-card { border: 1px solid var(--border-color); border-radius: 10px; overflow: hidden; background:#fff; }
-.article-card__image-wrap img { width:100%; aspect-ratio: 4/3; object-fit: cover; display:block; }
+.article-card__image-wrap img { width:100%; aspect-ratio: 4/3; object-fit: contain; display:block; background: #f8fafc; }
 .article-card__body { padding: 0.75rem 0.85rem 0.9rem; }
 .article-card h3 { margin: 0; font-size: 1rem; line-height: 1.35; }
 

--- a/js/main.js
+++ b/js/main.js
@@ -299,7 +299,7 @@ document.addEventListener('DOMContentLoaded', function () {
     var articleToggle = document.querySelector('.article-nav__toggle');
     var articlePanel = document.querySelector('.article-nav__panel');
     var articles = document.querySelectorAll('.article-section article');
-    var startHereGrid = document.querySelector('#startHereGrid');
+    var featuredArticleSpotlight = document.querySelector('#featuredArticleSpotlight');
     var articleDiscoveryGrid = document.querySelector('#articleDiscoveryGrid');
     var blogFilterButtons = document.querySelector('#blogFilterButtons');
 
@@ -308,17 +308,17 @@ document.addEventListener('DOMContentLoaded', function () {
         'great-physique-timeline': { topic: 'Muscle building', date: '2026-01-08', startHere: true },
         'coffee-caffeine-performance': { topic: 'Nutrition', date: '2026-01-14', startHere: false },
         'lead-in-protein-powder': { topic: 'Supplements', date: '2026-01-18', startHere: false },
-        'best-training-split': { topic: 'Programming', date: '2026-01-23', startHere: false },
+        'best-training-split': { topic: 'Science', date: '2026-01-23', startHere: false },
         'pump-feels-good': { topic: 'Muscle building', date: '2026-01-30', startHere: false },
         'twinkie-diet': { topic: 'Fat loss', date: '2026-02-04', startHere: false },
-        'effective-reps': { topic: 'Programming', date: '2026-02-09', startHere: false },
+        'effective-reps': { topic: 'Science', date: '2026-02-09', startHere: false },
         'big-bench-press': { topic: 'Strength', date: '2026-02-14', startHere: false },
         'day-one-plan': { topic: 'Beginner training', date: '2026-02-20', startHere: true },
         'not-gaining-muscle': { topic: 'Muscle building', date: '2026-02-24', startHere: false },
-        'consistency-beats-motivation': { topic: 'Mindset', date: '2026-03-02', startHere: false },
+        'consistency-beats-motivation': { topic: 'Motivation', date: '2026-03-02', startHere: false },
         'cheat-code-losing-weight': { topic: 'Fat loss', date: '2026-03-09', startHere: false },
         'correct-way-to-bulk': { topic: 'Nutrition', date: '2026-03-16', startHere: false },
-        'why-youre-stuck-checklist': { topic: 'Programming', date: '2026-04-16', startHere: false }
+        'why-youre-stuck-checklist': { topic: 'Science', date: '2026-04-16', startHere: false }
     };
 
     var prettyDate = function (isoDate) {
@@ -339,6 +339,7 @@ document.addEventListener('DOMContentLoaded', function () {
         articles.forEach(function (article, index) {
             var heading = article.querySelector('h2');
             var firstParagraph = article.querySelector('p');
+            var articleImage = article.querySelector('img');
             var targetId = article.getAttribute('id');
             if (!heading || !targetId) {
                 return;
@@ -390,18 +391,18 @@ document.addEventListener('DOMContentLoaded', function () {
                 topic: configuredMeta.topic,
                 date: configuredMeta.date,
                 readTime: readTime,
+                image: articleImage ? articleImage.getAttribute('src') : 'PersonalTrainingAILogo.jpeg',
+                imageAlt: articleImage ? articleImage.getAttribute('alt') : heading.textContent.trim() + ' article image',
                 excerpt: excerpt,
                 startHere: configuredMeta.startHere
             });
         });
 
         if (articleDiscoveryGrid && articleCards.length) {
-            var topics = ['all'];
-            articleCards.forEach(function (card) {
-                var normalized = card.topic.toLowerCase();
-                if (topics.indexOf(normalized) === -1) {
-                    topics.push(normalized);
-                }
+            var topicOrder = ['all', 'beginner training', 'muscle building', 'fat loss', 'nutrition', 'supplements', 'science', 'motivation'];
+            var availableTopics = articleCards.map(function (card) { return card.topic.toLowerCase(); });
+            var topics = topicOrder.filter(function (topic) {
+                return topic === 'all' || availableTopics.indexOf(topic) !== -1;
             });
 
             if (blogFilterButtons) {
@@ -427,9 +428,9 @@ document.addEventListener('DOMContentLoaded', function () {
                 filteredCards.forEach(function (card) {
                     var cardArticle = document.createElement('article');
                     cardArticle.className = 'article-card';
-                    cardArticle.innerHTML = '<p class="article-card__meta">' + card.topic + ' • ' + prettyDate(card.date) + ' • ' + card.readTime + ' min read</p>'
-                        + '<h3><a href="#' + card.id + '">' + card.title + '</a></h3>'
-                        + '<p>' + card.excerpt + '</p>';
+                    cardArticle.innerHTML = '<a class="article-card__link" href="#' + card.id + '"><div class="article-card__image-wrap"><img src="' + card.image + '" alt="' + card.imageAlt + '" loading="lazy"></div>'
+                        + '<div class="article-card__body"><h3>' + card.title + '</h3>'
+                        + '<p class="article-card__meta">' + card.topic + ' • ' + prettyDate(card.date) + ' • ' + card.readTime + ' min read</p></div></a>';
                     articleDiscoveryGrid.appendChild(cardArticle);
 
                     var articleNode = document.getElementById(card.id);
@@ -450,16 +451,12 @@ document.addEventListener('DOMContentLoaded', function () {
 
             renderDiscoveryCards('all');
 
-            if (startHereGrid) {
-                startHereGrid.innerHTML = '';
-                articleCards.filter(function (card) { return card.startHere; }).slice(0, 3).forEach(function (card) {
-                    var startCard = document.createElement('article');
-                    startCard.className = 'start-here-card';
-                    startCard.innerHTML = '<p class="article-card__meta">' + card.topic + ' • ' + card.readTime + ' min read</p>'
-                        + '<h3><a href="#' + card.id + '">' + card.title + '</a></h3>'
-                        + '<p>' + card.excerpt + '</p>';
-                    startHereGrid.appendChild(startCard);
-                });
+            if (featuredArticleSpotlight && articleCards.length) {
+                var featured = articleCards.slice().sort(function (a, b) { return new Date(b.date) - new Date(a.date); })[0];
+                featuredArticleSpotlight.innerHTML = '<a class="featured-article-card" href="#' + featured.id + '">'
+                    + '<img src="' + featured.image + '" alt="' + featured.imageAlt + '" loading="lazy">'
+                    + '<div class="featured-article-card__content"><p class="article-card__meta">' + featured.topic + ' • ' + prettyDate(featured.date) + ' • ' + featured.readTime + ' min read</p>'
+                    + '<h3>' + featured.title + '</h3></div></a>';
             }
 
             if (blogFilterButtons) {


### PR DESCRIPTION
### Motivation
- Make the Articles page cleaner and easier to scan by converting long text previews into an image-first article library with a single featured article and compact cards. 
- Preserve all existing article content, links, images, SEO metadata and the site header/footer while improving discovery and filtering.

### Description
- Replaced the previous “Start here” block with a `featuredArticleSpotlight` container in `articles.html` to expose the newest article as a larger, image-forward hero. 
- Reworked the discovery rendering in `js/main.js` to build fully clickable, image-first article cards showing image, title, category/topic, pretty date and read time and removed long preview paragraphs; cards link to in-page article anchors. 
- Added per-article image/alt fallbacks and a featured selection (newest article by date) in `js/main.js`, and applied a predefined topic ordering that only exposes categories present in the content. 
- Updated `css/style.css` with Articles-page-only styles: consistent image aspect ratios for featured (16:9) and grid cards (4:3), responsive 1/2/3 column behavior, tighter spacing, compact topic filter buttons, and removal of the previous large pill visual treatment.

### Testing
- Inspected the modified HTML fragment with `nl -ba articles.html | sed -n '44,74p'` to confirm the featured spotlight insertion, and it succeeded. 
- Reviewed the updated discovery logic in `js/main.js` with `nl -ba js/main.js | sed -n '296,490p'` to confirm card rendering, featured selection, topic ordering and image fallbacks, and it succeeded. 
- Verified the new Articles-specific styles with `nl -ba css/style.css | sed -n '1340,1455p'` to confirm aspect-ratio, grid and filter button rules, and it succeeded. 
- Confirmed repository file listing with `rg --files | head -n 200` to ensure assets referenced by cards exist, and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd339780c483268932dc40b18a5b9c)