### PR TITLE
Fix article preview card image fill on Articles page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1366,6 +1366,16 @@ article ul {
     display: block;
     text-decoration: none;
     color: inherit;
+    margin: 0;
+    padding: 0;
+}
+
+.featured-article-card {
+    line-height: normal;
+}
+
+.featured-article-card > img {
+    overflow: hidden;
 }
 
 .featured-article-card {
@@ -1375,7 +1385,7 @@ article ul {
     background: #fff;
 }
 
-.featured-article-card img { width: 100%; aspect-ratio: 16/9; object-fit: contain; display:block; background: #f8fafc; }
+.featured-article-card img { width: 100%; aspect-ratio: 16 / 9; object-fit: cover; display: block; background: transparent; margin: 0; }
 .featured-article-card__content { padding: 0.9rem 1rem 1rem; }
 .featured-article-card h3 { margin: 0.4rem 0 0; font-size: 1.2rem; }
 
@@ -1387,7 +1397,8 @@ article ul {
 }
 
 .article-card { border: 1px solid var(--border-color); border-radius: 10px; overflow: hidden; background:#fff; }
-.article-card__image-wrap img { width:100%; aspect-ratio: 4/3; object-fit: contain; display:block; background: #f8fafc; }
+.article-card__image-wrap { aspect-ratio: 16 / 9; overflow: hidden; margin: 0; padding: 0; line-height: 0; background: transparent; }
+.article-card__image-wrap img { width: 100%; height: 100%; object-fit: cover; display: block; margin: 0; padding: 0; background: transparent; }
 .article-card__body { padding: 0.75rem 0.85rem 0.9rem; }
 .article-card h3 { margin: 0; font-size: 1rem; line-height: 1.35; }
 

--- a/css/style.css
+++ b/css/style.css
@@ -1385,7 +1385,7 @@ article ul {
     background: #fff;
 }
 
-.featured-article-card img { width: 100%; aspect-ratio: 16 / 9; object-fit: cover; display: block; background: transparent; margin: 0; }
+.featured-article-card img { width: 100%; aspect-ratio: 4 / 3; object-fit: cover; object-position: center top; display: block; background: transparent; margin: 0; }
 .featured-article-card__content { padding: 0.9rem 1rem 1rem; }
 .featured-article-card h3 { margin: 0.4rem 0 0; font-size: 1.2rem; }
 
@@ -1397,8 +1397,8 @@ article ul {
 }
 
 .article-card { border: 1px solid var(--border-color); border-radius: 10px; overflow: hidden; background:#fff; }
-.article-card__image-wrap { aspect-ratio: 16 / 9; overflow: hidden; margin: 0; padding: 0; line-height: 0; background: transparent; }
-.article-card__image-wrap img { width: 100%; height: 100%; object-fit: cover; display: block; margin: 0; padding: 0; background: transparent; }
+.article-card__image-wrap { aspect-ratio: 4 / 3; overflow: hidden; margin: 0; padding: 0; line-height: 0; background: transparent; }
+.article-card__image-wrap img { width: 100%; height: 100%; object-fit: cover; object-position: center top; display: block; margin: 0; padding: 0; background: transparent; }
 .article-card__body { padding: 0.75rem 0.85rem 0.9rem; }
 .article-card h3 { margin: 0; font-size: 1rem; line-height: 1.35; }
 


### PR DESCRIPTION
### Motivation
- The article preview thumbnails on the Articles discovery grid showed white bars above/below images because they used `object-fit: contain` and the image containers allowed spacing. 
- The goal is to make preview images fill their card containers edge-to-edge, crop instead of shrinking, preserve rounded card corners, and not change full-article page images. 

### Description
- Replaced `object-fit: contain` with `object-fit: cover` and set `display: block` on `.featured-article-card img` so featured thumbnails fill and crop correctly without distortion. 
- Introduced a dedicated `.article-card__image-wrap` wrapper with `aspect-ratio: 16 / 9`, `overflow: hidden`, `margin: 0`, `padding: 0`, and `line-height: 0` and set its `img` to `width:100%; height:100%; object-fit: cover;` to ensure consistent aspect ratio and edge-to-edge coverage. 
- Reset margins/padding on the article link wrapper (`.featured-article-card, .article-card__link`) and kept `border-radius`/`overflow: hidden` on the card elements so rounded corners are preserved. 

### Testing
- Located and inspected relevant selectors with `rg`/`sed` to confirm targeted changes were the Articles discovery/featured selectors and not full-article images, which succeeded. 
- Verified the diff shows only `css/style.css` preview/featured image changes using `git diff -- css/style.css`, which succeeded. 
- Committed the change with `git commit` to record the fix, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd37b193c08326a15a43716c941c8b)