### PR TITLE
Fix preview thumbnails to fully fill article cards

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1375,7 +1375,7 @@ article ul {
     background: #fff;
 }
 
-.featured-article-card img { width: 100%; aspect-ratio: 16/9; object-fit: contain; display:block; background: #f8fafc; }
+.featured-article-card img { width: 100%; aspect-ratio: 16/9; object-fit: cover; display: block; margin: 0; padding: 0; }
 .featured-article-card__content { padding: 0.9rem 1rem 1rem; }
 .featured-article-card h3 { margin: 0.4rem 0 0; font-size: 1.2rem; }
 
@@ -1387,7 +1387,8 @@ article ul {
 }
 
 .article-card { border: 1px solid var(--border-color); border-radius: 10px; overflow: hidden; background:#fff; }
-.article-card__image-wrap img { width:100%; aspect-ratio: 4/3; object-fit: contain; display:block; background: #f8fafc; }
+.article-card__image-wrap { aspect-ratio: 4 / 3; overflow: hidden; margin: 0; padding: 0; line-height: 0; }
+.article-card__image-wrap img { width: 100%; height: 100%; object-fit: cover; display: block; margin: 0; padding: 0; }
 .article-card__body { padding: 0.75rem 0.85rem 0.9rem; }
 .article-card h3 { margin: 0; font-size: 1rem; line-height: 1.35; }
 


### PR DESCRIPTION
### Motivation
- Article preview thumbnails on the Articles page showed white bars above and below images because they were shrinking to fit instead of cropping, producing inconsistent spacing across cards. 
- The intent is to make preview images fill their card image area edge-to-edge with consistent aspect ratios while preserving rounded card corners and not altering full-article images. 
- The fix must work on both desktop and mobile and avoid stretching or distorting images.

### Description
- Changed `.featured-article-card img` from `object-fit: contain` to `object-fit: cover` and applied `display: block` with zero `margin`/`padding` so the featured thumbnail fills its 16:9 container. 
- Added an explicit `.article-card__image-wrap` container with `aspect-ratio: 4 / 3`, `overflow: hidden`, `margin: 0`, `padding: 0`, and `line-height: 0` to prevent parent spacing from creating gaps. 
- Updated `.article-card__image-wrap img` to `width: 100%; height: 100%; object-fit: cover; display: block; margin: 0; padding: 0;` so grid thumbnails crop correctly without distortion. 
- Scoped changes to preview selectors only so full-article page images remain untouched and card rounded corners stay intact via the existing `overflow: hidden` on the card.

### Testing
- Ran a targeted search with `rg` across `css/style.css`, `js/main.js`, and `articles.html` to confirm selectors affected were limited to preview/featured card rules and the search completed successfully. 
- Printed the edited CSS region with `nl -ba css/style.css | sed -n '1360,1410p'` to verify the new rules (`object-fit: cover`, `.article-card__image-wrap` container, and zero spacing) were present and correct.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd39b293d48326aaa52ee1309ae243)