### PR TITLE
Refine Articles page into compact image-first card library

### DIFF
--- a/articles.html
+++ b/articles.html
@@ -47,38 +47,12 @@
     <section class="article-section">
         <section class="blog-discovery" aria-labelledby="blogDiscoveryHeading">
             <div class="blog-discovery__intro">
-                <h2 id="blogDiscoveryHeading">Featured article</h2>
-                <p>Latest coaching insight from Matt.</p>
-            </div>
-            <div class="featured-article-spotlight" id="featuredArticleSpotlight">
-                <p class="article-nav__empty">Loading featured article…</p>
-            </div>
-            <div class="blog-filters" aria-label="Filter articles by topic">
-                <h3>Browse by topic</h3>
-                <div class="blog-filters__buttons" id="blogFilterButtons">
-                    <button type="button" class="blog-filter is-active" data-topic="all" aria-pressed="true">All topics</button>
-                </div>
+                <h2 id="blogDiscoveryHeading">Article library</h2>
             </div>
             <div class="article-discovery-grid" id="articleDiscoveryGrid" aria-live="polite">
-                <p class="article-nav__empty">Loading article previews…</p>
+                <p class="article-nav__empty">Loading articles…</p>
             </div>
         </section>
-        <nav class="article-nav article-nav--closed" aria-label="Jump to an Article">
-            <button class="article-nav__toggle" aria-expanded="false" aria-controls="articleNavPanel">
-                Jump to an Article
-            </button>
-            <div class="article-nav__panel" id="articleNavPanel" hidden>
-                <div class="article-nav__header">
-                    <div>
-                        <h2>Jump to an Article</h2>
-                        <p class="article-nav__hint">Tap a title below to move straight to it. Tap the button again to hide this list.</p>
-                    </div>
-                </div>
-                <ul class="article-nav__list" aria-live="polite">
-                    <li class="article-nav__empty">Loading article list…</li>
-                </ul>
-            </div>
-        </nav>
         <article id="day-one-start-lifting">
             <img src="C7D364DB-2726-41E8-A64D-60C85B18C5DD.png" alt="Day One Exactly What to Do article image">
             <h2>Day One: Exactly What to Do When You Start Lifting</h2>

--- a/css/style.css
+++ b/css/style.css
@@ -1356,7 +1356,7 @@ article ul {
     border: 0;
     border-radius: 0;
     padding: 0;
-    margin-bottom: 1.2rem;
+    margin-bottom: 1rem;
 }
 
 .featured-article-spotlight { margin-top: 0.9rem; }
@@ -1381,14 +1381,15 @@ article ul {
 
 .article-discovery-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-    gap: 1rem;
-    margin-top: 1rem;
+    grid-template-columns: 1fr;
+    gap: 0.85rem;
+    margin-top: 0.8rem;
 }
 
-.article-card { border: 1px solid var(--border-color); border-radius: 10px; overflow: hidden; background:#fff; }
-.article-card__image-wrap img { width:100%; aspect-ratio: 4/3; object-fit: contain; display:block; background: #f8fafc; }
-.article-card__body { padding: 0.75rem 0.85rem 0.9rem; }
+.article-card { border: 1px solid var(--border-color); border-radius: 6px; overflow: hidden; background:#fff; }
+.article-card__image-wrap { overflow: hidden; }
+.article-card__image-wrap img { width:100%; aspect-ratio: 4/3; object-fit: cover; display:block; background: #f8fafc; }
+.article-card__body { padding: 0.6rem 0.75rem 0.7rem; }
 .article-card h3 { margin: 0; font-size: 1rem; line-height: 1.35; }
 
 .article-card__meta { margin: 0.45rem 0 0; font-family: 'Open Sans', Arial, sans-serif; font-size: 0.82rem; color: #475569; font-weight: 700; }
@@ -1411,9 +1412,12 @@ article ul {
     scroll-margin-top: 1rem;
 }
 
-@media (max-width: 760px) {
-    .article-discovery-grid { grid-template-columns: 1fr; gap: 0.8rem; }
-    .featured-article-card h3 { font-size: 1.05rem; }
+@media (min-width: 700px) {
+    .article-discovery-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+
+@media (min-width: 1080px) {
+    .article-discovery-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
 }
 /* Calculator card styling */
 .calculator-section {

--- a/js/main.js
+++ b/js/main.js
@@ -294,14 +294,8 @@ document.addEventListener('DOMContentLoaded', function () {
         renderGoalRecommendation('fat-loss');
     }
 
-    var articleNav = document.querySelector('.article-nav');
-    var articleList = document.querySelector('.article-nav__list');
-    var articleToggle = document.querySelector('.article-nav__toggle');
-    var articlePanel = document.querySelector('.article-nav__panel');
     var articles = document.querySelectorAll('.article-section article');
-    var featuredArticleSpotlight = document.querySelector('#featuredArticleSpotlight');
     var articleDiscoveryGrid = document.querySelector('#articleDiscoveryGrid');
-    var blogFilterButtons = document.querySelector('#blogFilterButtons');
 
     var articleMetaConfig = {
         'day-one-start-lifting': { topic: 'Beginner training', date: '2026-01-03', startHere: true },
@@ -333,10 +327,8 @@ document.addEventListener('DOMContentLoaded', function () {
 
     var articleCards = [];
 
-    if (articleNav && articleList && articles.length) {
-        articleList.innerHTML = '';
-
-        articles.forEach(function (article, index) {
+    if (articleDiscoveryGrid && articles.length) {
+        articles.forEach(function (article) {
             var heading = article.querySelector('h2');
             var firstParagraph = article.querySelector('p');
             var articleImage = article.querySelector('img');
@@ -351,12 +343,6 @@ document.addEventListener('DOMContentLoaded', function () {
                 startHere: false
             };
             var readTime = computeReadTime(article);
-            var excerpt = firstParagraph ? firstParagraph.textContent.trim() : 'Read this article for practical coaching guidance.';
-
-            if (firstParagraph) {
-                firstParagraph.classList.add('article-excerpt');
-            }
-
             var existingMetaRow = article.querySelector('.article-meta');
             if (!existingMetaRow) {
                 var metaRow = document.createElement('p');
@@ -364,26 +350,6 @@ document.addEventListener('DOMContentLoaded', function () {
                 metaRow.textContent = configuredMeta.topic + ' • ' + prettyDate(configuredMeta.date) + ' • ' + readTime + ' min read';
                 article.insertBefore(metaRow, firstParagraph || heading.nextSibling);
             }
-
-            var listItem = document.createElement('li');
-            var link = document.createElement('a');
-            link.href = '#' + targetId;
-            link.textContent = (index + 1) + '. ' + heading.textContent.trim();
-            link.addEventListener('click', function (event) {
-                event.preventDefault();
-                var target = document.getElementById(targetId);
-                if (target) {
-                    target.scrollIntoView({ behavior: 'smooth', block: 'start' });
-                    if (history.pushState) {
-                        history.pushState(null, '', '#' + targetId);
-                    } else {
-                        window.location.hash = targetId;
-                    }
-                }
-            });
-
-            listItem.appendChild(link);
-            articleList.appendChild(listItem);
 
             articleCards.push({
                 id: targetId,
@@ -393,116 +359,22 @@ document.addEventListener('DOMContentLoaded', function () {
                 readTime: readTime,
                 image: articleImage ? articleImage.getAttribute('src') : 'PersonalTrainingAILogo.jpeg',
                 imageAlt: articleImage ? articleImage.getAttribute('alt') : heading.textContent.trim() + ' article image',
-                excerpt: excerpt,
                 startHere: configuredMeta.startHere
             });
         });
 
-        if (articleDiscoveryGrid && articleCards.length) {
-            var topicOrder = ['all', 'beginner training', 'muscle building', 'fat loss', 'nutrition', 'supplements', 'science', 'motivation'];
-            var availableTopics = articleCards.map(function (card) { return card.topic.toLowerCase(); });
-            var topics = topicOrder.filter(function (topic) {
-                return topic === 'all' || availableTopics.indexOf(topic) !== -1;
+        if (articleCards.length) {
+            articleDiscoveryGrid.innerHTML = '';
+            articleCards.forEach(function (card) {
+                var cardArticle = document.createElement('article');
+                cardArticle.className = 'article-card';
+                cardArticle.innerHTML = '<a class="article-card__link" href="#' + card.id + '"><div class="article-card__image-wrap"><img src="' + card.image + '" alt="' + card.imageAlt + '" loading="lazy"></div>'
+                    + '<div class="article-card__body"><h3>' + card.title + '</h3>'
+                    + '<p class="article-card__meta">' + card.topic + ' • ' + prettyDate(card.date) + ' • ' + card.readTime + ' min read</p></div></a>';
+                articleDiscoveryGrid.appendChild(cardArticle);
             });
-
-            if (blogFilterButtons) {
-                blogFilterButtons.innerHTML = '';
-                topics.forEach(function (topic) {
-                    var filterButton = document.createElement('button');
-                    var readableTopic = topic === 'all' ? 'All topics' : topic.replace(/\b\w/g, function (char) { return char.toUpperCase(); });
-                    filterButton.type = 'button';
-                    filterButton.className = 'blog-filter' + (topic === 'all' ? ' is-active' : '');
-                    filterButton.setAttribute('data-topic', topic);
-                    filterButton.setAttribute('aria-pressed', topic === 'all' ? 'true' : 'false');
-                    filterButton.textContent = readableTopic;
-                    blogFilterButtons.appendChild(filterButton);
-                });
-            }
-
-            var renderDiscoveryCards = function (activeTopic) {
-                articleDiscoveryGrid.innerHTML = '';
-                var filteredCards = articleCards.filter(function (card) {
-                    return activeTopic === 'all' || card.topic.toLowerCase() === activeTopic;
-                });
-
-                filteredCards.forEach(function (card) {
-                    var cardArticle = document.createElement('article');
-                    cardArticle.className = 'article-card';
-                    cardArticle.innerHTML = '<a class="article-card__link" href="#' + card.id + '"><div class="article-card__image-wrap"><img src="' + card.image + '" alt="' + card.imageAlt + '" loading="lazy"></div>'
-                        + '<div class="article-card__body"><h3>' + card.title + '</h3>'
-                        + '<p class="article-card__meta">' + card.topic + ' • ' + prettyDate(card.date) + ' • ' + card.readTime + ' min read</p></div></a>';
-                    articleDiscoveryGrid.appendChild(cardArticle);
-
-                    var articleNode = document.getElementById(card.id);
-                    if (articleNode) {
-                        articleNode.hidden = false;
-                    }
-                });
-
-                articles.forEach(function (articleNode) {
-                    var id = articleNode.getAttribute('id');
-                    var nodeCard = articleCards.find(function (card) { return card.id === id; });
-                    if (!nodeCard) {
-                        return;
-                    }
-                    articleNode.hidden = !(activeTopic === 'all' || nodeCard.topic.toLowerCase() === activeTopic);
-                });
-            };
-
-            renderDiscoveryCards('all');
-
-            if (featuredArticleSpotlight && articleCards.length) {
-                var featured = articleCards.slice().sort(function (a, b) { return new Date(b.date) - new Date(a.date); })[0];
-                featuredArticleSpotlight.innerHTML = '<a class="featured-article-card" href="#' + featured.id + '">'
-                    + '<img src="' + featured.image + '" alt="' + featured.imageAlt + '" loading="lazy">'
-                    + '<div class="featured-article-card__content"><p class="article-card__meta">' + featured.topic + ' • ' + prettyDate(featured.date) + ' • ' + featured.readTime + ' min read</p>'
-                    + '<h3>' + featured.title + '</h3></div></a>';
-            }
-
-            if (blogFilterButtons) {
-                blogFilterButtons.addEventListener('click', function (event) {
-                    var button = event.target.closest('.blog-filter');
-                    if (!button) {
-                        return;
-                    }
-                    var activeTopic = button.getAttribute('data-topic');
-                    var allButtons = blogFilterButtons.querySelectorAll('.blog-filter');
-                    allButtons.forEach(function (item) {
-                        var isActive = item === button;
-                        item.classList.toggle('is-active', isActive);
-                        item.setAttribute('aria-pressed', isActive ? 'true' : 'false');
-                    });
-                    renderDiscoveryCards(activeTopic);
-                });
-            }
+        } else {
+            articleDiscoveryGrid.innerHTML = '<p class="article-nav__empty">No articles found.</p>';
         }
-
-        if (!articleList.children.length) {
-            articleList.innerHTML = '<li class="article-nav__empty">No articles found.</li>';
-        }
-
-        var setPanelState = function (isOpen) {
-            articleNav.classList.toggle('article-nav--open', isOpen);
-            articleNav.classList.toggle('article-nav--closed', !isOpen);
-            if (articlePanel) {
-                articlePanel.hidden = !isOpen;
-            }
-            if (articleToggle) {
-                articleToggle.setAttribute('aria-expanded', isOpen);
-            }
-        };
-
-        if (articleToggle && articlePanel) {
-            articleToggle.addEventListener('click', function () {
-                var isOpen = articlePanel.hidden;
-                setPanelState(isOpen);
-            });
-        }
-
-        document.addEventListener('keydown', function (event) {
-            if (event.key === 'Escape' && articleNav.classList.contains('article-nav--open')) {
-                setPanelState(false);
-            }
-        });
     }
 });


### PR DESCRIPTION
### Motivation
- Make the Articles page a clean, image-first library by removing preview/excerpt text and expandable previews so each item reads as a visual tile. 
- Turn each article into a single clickable card that opens the full article page while preserving the full article pages unchanged. 
- Provide a compact, responsive grid that is easy to scan (mobile 1 column, tablet 2 columns, desktop 3 columns) and remove navigation clutter.

### Description
- Removed the featured/preview blocks, topic filter markup, and the jump-link navigation from `articles.html` and replaced the heading with a compact “Article library” grid. 
- Simplified `js/main.js` to stop extracting or injecting paragraph excerpts, removed the article-nav and expansive discovery/filter/featured logic, and instead build `articleCards` that render a single anchor-wrapped tile per article containing only image, title, topic, date, and read time. 
- Made the entire card clickable by wrapping the card contents in an `<a>` (`.article-card__link`) that anchors to the full article ID. 
- Tightened CSS in `css/style.css`: set the grid to a compact gap, added image-wrapper `overflow: hidden`, switched images to `object-fit: cover` and `display: block`, reduced card radius and padding, and added breakpoints for 1/2/3 column responsive layout.
- Preserved all full article content, header/footer, colors, links, and SEO metadata; article bodies still exist in the page and are reachable via the card anchors.

### Testing
- Inspected repository and staged/committed changes using `git add articles.html css/style.css js/main.js && git commit -m "Refine articles page into compact clickable visual library"`, which completed successfully. 
- Verified resulting file changes and snippets with `nl -ba articles.html | sed -n '40,95p'`, `nl -ba js/main.js | sed -n '292,410p'`, and `nl -ba css/style.css | sed -n '1348,1435p'`, each command returning the expected output. 
- Created the PR payload programmatically and produced the PR title/body via the internal `make_pr` call, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd4ab0f60083269ef32d84b109bf33)