### PR TITLE
Fix article preview thumbnails to prevent cropping

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1371,11 +1371,10 @@ article ul {
 .featured-article-card {
     border: 1px solid var(--border-color);
     border-radius: 12px;
-    overflow: hidden;
     background: #fff;
 }
 
-.featured-article-card img { width: 100%; aspect-ratio: 16/9; object-fit: contain; display:block; background: #f8fafc; }
+.featured-article-card img { width: 100%; height: auto; object-fit: contain; display:block; background: #f8fafc; border-radius: 12px 12px 0 0; }
 .featured-article-card__content { padding: 0.9rem 1rem 1rem; }
 .featured-article-card h3 { margin: 0.4rem 0 0; font-size: 1.2rem; }
 
@@ -1386,8 +1385,9 @@ article ul {
     margin-top: 1rem;
 }
 
-.article-card { border: 1px solid var(--border-color); border-radius: 10px; overflow: hidden; background:#fff; }
-.article-card__image-wrap img { width:100%; aspect-ratio: 4/3; object-fit: contain; display:block; background: #f8fafc; }
+.article-card { border: 1px solid var(--border-color); border-radius: 10px; background:#fff; }
+.article-card__image-wrap { overflow: visible; }
+.article-card__image-wrap img { width:100%; height: auto; object-fit: contain; display:block; background: #f8fafc; border-radius: 10px 10px 0 0; }
 .article-card__body { padding: 0.75rem 0.85rem 0.9rem; }
 .article-card h3 { margin: 0; font-size: 1rem; line-height: 1.35; }
 


### PR DESCRIPTION
### Motivation
- Article preview thumbnails were being cropped by fixed-height/aspect-ratio and clipped wrappers, causing designer-created full-summary graphics to lose edges.
- The intent is to make Articles page preview images render identically to full article images by removing forced cropping and preserving original aspect ratio.

### Description
- Updated `css/style.css` to remove `overflow: hidden` from preview card containers and removed fixed `aspect-ratio` constraints for featured and grid previews.
- Ensured preview images use `width: 100%`, `height: auto`, and `object-fit: contain`, and applied rounded corners to the image elements instead of clipped wrappers.
- Set `.article-card__image-wrap` to `overflow: visible` so wrapper does not crop images and allowed card height to naturally follow the image height.
- Changes are scoped to the Articles page discovery/preview card styles only and do not modify full article pages.

### Testing
- Ran a selector search with `rg -n "featured-article-card img|article-card__image-wrap|article-card \{|object-fit: cover|aspect-ratio" css/style.css` to verify the updated rules were present and the old constraints removed, which succeeded.
- Inspected the updated region with `nl -ba css/style.css | sed -n '1366,1400p'` to confirm `width: 100%`, `height: auto`, `object-fit: contain`, removal of `overflow: hidden`, and `overflow: visible` on the wrapper, which succeeded.
- No automated visual regression tests exist in the repo; changes were limited to `css/style.css` to minimize risk.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd4bf61e748326a3117163ec7a5309)