### PR TITLE
Refine Articles page into compact clickable image-first library

### DIFF
--- a/articles.html
+++ b/articles.html
@@ -47,11 +47,7 @@
     <section class="article-section">
         <section class="blog-discovery" aria-labelledby="blogDiscoveryHeading">
             <div class="blog-discovery__intro">
-                <h2 id="blogDiscoveryHeading">Featured article</h2>
-                <p>Latest coaching insight from Matt.</p>
-            </div>
-            <div class="featured-article-spotlight" id="featuredArticleSpotlight">
-                <p class="article-nav__empty">Loading featured article…</p>
+                <h2 id="blogDiscoveryHeading">Article library</h2>
             </div>
             <div class="blog-filters" aria-label="Filter articles by topic">
                 <h3>Browse by topic</h3>
@@ -60,25 +56,9 @@
                 </div>
             </div>
             <div class="article-discovery-grid" id="articleDiscoveryGrid" aria-live="polite">
-                <p class="article-nav__empty">Loading article previews…</p>
+                <p class="article-nav__empty">Loading articles…</p>
             </div>
         </section>
-        <nav class="article-nav article-nav--closed" aria-label="Jump to an Article">
-            <button class="article-nav__toggle" aria-expanded="false" aria-controls="articleNavPanel">
-                Jump to an Article
-            </button>
-            <div class="article-nav__panel" id="articleNavPanel" hidden>
-                <div class="article-nav__header">
-                    <div>
-                        <h2>Jump to an Article</h2>
-                        <p class="article-nav__hint">Tap a title below to move straight to it. Tap the button again to hide this list.</p>
-                    </div>
-                </div>
-                <ul class="article-nav__list" aria-live="polite">
-                    <li class="article-nav__empty">Loading article list…</li>
-                </ul>
-            </div>
-        </nav>
         <article id="day-one-start-lifting">
             <img src="C7D364DB-2726-41E8-A64D-60C85B18C5DD.png" alt="Day One Exactly What to Do article image">
             <h2>Day One: Exactly What to Do When You Start Lifting</h2>

--- a/css/style.css
+++ b/css/style.css
@@ -1356,7 +1356,7 @@ article ul {
     border: 0;
     border-radius: 0;
     padding: 0;
-    margin-bottom: 1.2rem;
+    margin-bottom: 0.8rem;
 }
 
 .featured-article-spotlight { margin-top: 0.9rem; }
@@ -1380,23 +1380,23 @@ article ul {
 
 .article-discovery-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-    gap: 1rem;
-    margin-top: 1rem;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.8rem;
+    margin-top: 0.75rem;
 }
 
-.article-card { border: 1px solid var(--border-color); border-radius: 10px; background:#fff; }
-.article-card__image-wrap { overflow: visible; }
-.article-card__image-wrap img { width:100%; height: auto; object-fit: contain; display:block; background: #f8fafc; border-radius: 10px 10px 0 0; }
-.article-card__body { padding: 0.75rem 0.85rem 0.9rem; }
+.article-card { border: 1px solid var(--border-color); border-radius: 6px; background:#fff; overflow: hidden; }
+.article-card__image-wrap { overflow: hidden; aspect-ratio: 16 / 10; }
+.article-card__image-wrap img { width:100%; height: 100%; object-fit: cover; display:block; }
+.article-card__body { padding: 0.65rem 0.75rem 0.8rem; }
 .article-card h3 { margin: 0; font-size: 1rem; line-height: 1.35; }
 
 .article-card__meta { margin: 0.45rem 0 0; font-family: 'Open Sans', Arial, sans-serif; font-size: 0.82rem; color: #475569; font-weight: 700; }
 
-.blog-filters { margin-top: 1rem; }
+.blog-filters { margin-top: 0.75rem; }
 .blog-filters h3 { margin: 0; font-size: 0.95rem; }
 .blog-filters__buttons { display:flex; flex-wrap:wrap; gap:0.5rem; margin-top:0.6rem; }
-.blog-filter { border: 1px solid var(--border-color); background: #fff; color: var(--primary-color); border-radius: 8px; padding: 0.3rem 0.65rem; font-weight: 700; cursor: pointer; }
+.blog-filter { border: 1px solid var(--border-color); background: transparent; color: var(--primary-color); border-radius: 4px; padding: 0.25rem 0.55rem; font-weight: 700; cursor: pointer; }
 .blog-filter.is-active { background: rgba(20, 184, 166, 0.15); border-color: var(--primary-color); color: #0f172a; }
 
 .article-section article[id] {
@@ -1411,8 +1411,14 @@ article ul {
     scroll-margin-top: 1rem;
 }
 
+@media (max-width: 1100px) {
+    .article-discovery-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
 @media (max-width: 760px) {
-    .article-discovery-grid { grid-template-columns: 1fr; gap: 0.8rem; }
+    .article-discovery-grid { grid-template-columns: 1fr; gap: 0.7rem; }
     .featured-article-card h3 { font-size: 1.05rem; }
 }
 /* Calculator card styling */

--- a/js/main.js
+++ b/js/main.js
@@ -294,12 +294,7 @@ document.addEventListener('DOMContentLoaded', function () {
         renderGoalRecommendation('fat-loss');
     }
 
-    var articleNav = document.querySelector('.article-nav');
-    var articleList = document.querySelector('.article-nav__list');
-    var articleToggle = document.querySelector('.article-nav__toggle');
-    var articlePanel = document.querySelector('.article-nav__panel');
     var articles = document.querySelectorAll('.article-section article');
-    var featuredArticleSpotlight = document.querySelector('#featuredArticleSpotlight');
     var articleDiscoveryGrid = document.querySelector('#articleDiscoveryGrid');
     var blogFilterButtons = document.querySelector('#blogFilterButtons');
 
@@ -333,12 +328,9 @@ document.addEventListener('DOMContentLoaded', function () {
 
     var articleCards = [];
 
-    if (articleNav && articleList && articles.length) {
-        articleList.innerHTML = '';
-
-        articles.forEach(function (article, index) {
+    if (articles.length) {
+        articles.forEach(function (article) {
             var heading = article.querySelector('h2');
-            var firstParagraph = article.querySelector('p');
             var articleImage = article.querySelector('img');
             var targetId = article.getAttribute('id');
             if (!heading || !targetId) {
@@ -351,11 +343,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 startHere: false
             };
             var readTime = computeReadTime(article);
-            var excerpt = firstParagraph ? firstParagraph.textContent.trim() : 'Read this article for practical coaching guidance.';
-
-            if (firstParagraph) {
-                firstParagraph.classList.add('article-excerpt');
-            }
+            var firstParagraph = article.querySelector('p');
 
             var existingMetaRow = article.querySelector('.article-meta');
             if (!existingMetaRow) {
@@ -365,26 +353,6 @@ document.addEventListener('DOMContentLoaded', function () {
                 article.insertBefore(metaRow, firstParagraph || heading.nextSibling);
             }
 
-            var listItem = document.createElement('li');
-            var link = document.createElement('a');
-            link.href = '#' + targetId;
-            link.textContent = (index + 1) + '. ' + heading.textContent.trim();
-            link.addEventListener('click', function (event) {
-                event.preventDefault();
-                var target = document.getElementById(targetId);
-                if (target) {
-                    target.scrollIntoView({ behavior: 'smooth', block: 'start' });
-                    if (history.pushState) {
-                        history.pushState(null, '', '#' + targetId);
-                    } else {
-                        window.location.hash = targetId;
-                    }
-                }
-            });
-
-            listItem.appendChild(link);
-            articleList.appendChild(listItem);
-
             articleCards.push({
                 id: targetId,
                 title: heading.textContent.trim(),
@@ -393,7 +361,6 @@ document.addEventListener('DOMContentLoaded', function () {
                 readTime: readTime,
                 image: articleImage ? articleImage.getAttribute('src') : 'PersonalTrainingAILogo.jpeg',
                 imageAlt: articleImage ? articleImage.getAttribute('alt') : heading.textContent.trim() + ' article image',
-                excerpt: excerpt,
                 startHere: configuredMeta.startHere
             });
         });
@@ -451,14 +418,6 @@ document.addEventListener('DOMContentLoaded', function () {
 
             renderDiscoveryCards('all');
 
-            if (featuredArticleSpotlight && articleCards.length) {
-                var featured = articleCards.slice().sort(function (a, b) { return new Date(b.date) - new Date(a.date); })[0];
-                featuredArticleSpotlight.innerHTML = '<a class="featured-article-card" href="#' + featured.id + '">'
-                    + '<img src="' + featured.image + '" alt="' + featured.imageAlt + '" loading="lazy">'
-                    + '<div class="featured-article-card__content"><p class="article-card__meta">' + featured.topic + ' • ' + prettyDate(featured.date) + ' • ' + featured.readTime + ' min read</p>'
-                    + '<h3>' + featured.title + '</h3></div></a>';
-            }
-
             if (blogFilterButtons) {
                 blogFilterButtons.addEventListener('click', function (event) {
                     var button = event.target.closest('.blog-filter');
@@ -477,32 +436,5 @@ document.addEventListener('DOMContentLoaded', function () {
             }
         }
 
-        if (!articleList.children.length) {
-            articleList.innerHTML = '<li class="article-nav__empty">No articles found.</li>';
-        }
-
-        var setPanelState = function (isOpen) {
-            articleNav.classList.toggle('article-nav--open', isOpen);
-            articleNav.classList.toggle('article-nav--closed', !isOpen);
-            if (articlePanel) {
-                articlePanel.hidden = !isOpen;
-            }
-            if (articleToggle) {
-                articleToggle.setAttribute('aria-expanded', isOpen);
-            }
-        };
-
-        if (articleToggle && articlePanel) {
-            articleToggle.addEventListener('click', function () {
-                var isOpen = articlePanel.hidden;
-                setPanelState(isOpen);
-            });
-        }
-
-        document.addEventListener('keydown', function (event) {
-            if (event.key === 'Escape' && articleNav.classList.contains('article-nav--open')) {
-                setPanelState(false);
-            }
-        });
     }
 });


### PR DESCRIPTION
### Motivation
- Simplify the Articles page into an image-first, scannable library by removing preview text and expandable/jump navigation so each article appears as a clean clickable tile.
- Keep full article pages and their content untouched while improving discoverability and visual consistency on the listing page.

### Description
- Removed the featured spotlight block and the “Jump to an Article” jump-list UI from `articles.html` to reduce clutter and focus on the grid of cards.
- Simplified discovery logic in `js/main.js` by removing preview/excerpt extraction and jump-list generation while preserving per-article metadata (topic/date/read time) and topic filtering; cards are anchor-wrapped tiles that navigate to the full article section.
- Reworked styles in `css/style.css` to present a compact responsive grid (3 columns desktop, 2 columns tablet, 1 column mobile), tightened spacing and corner radii, and made image wrappers clip overflow with images using `object-fit: cover` and `display: block` to fill tiles cleanly.
- Preserved header/footer, SEO metadata, article content, and article links so full article pages remain unchanged.

### Testing
- Ran a repo diff check with `git diff -- articles.html js/main.js css/style.css` to confirm the intended edits (succeeded).
- Committed the changes with `git commit` to record the update (succeeded).
- Attempted a visual validation with `npx playwright screenshot ...` but Playwright could not be installed in this environment due to npm registry restrictions (failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd4d4cd1b083268340e87614189256)