### PR TITLE
Redesign site styling with premium dark performance aesthetic

### DIFF
--- a/about.html
+++ b/about.html
@@ -16,11 +16,9 @@
 <body>
     <nav class="site-nav">
         <a class="site-brand" href="index.html" aria-label="Matt McGinley Personal Training home">
-            <span class="site-brand__mark" aria-hidden="true"><span>MM</span></span>
-            <span class="site-brand__text">
-                <span class="site-brand__name">Matt McGinley</span>
-                <span class="site-brand__subtitle">Training</span>
-            </span>
+            <span class="site-brand__mark" aria-hidden="true">MM</span>
+            <span class="site-brand__divider" aria-hidden="true">|</span>
+            <span class="site-brand__name">Matt McGinley Training</span>
         </a>
         <button class="site-nav__toggle" type="button" aria-expanded="false" aria-controls="site-menu" aria-label="Open navigation menu">
             <span class="site-nav__hamburger" aria-hidden="true"></span>

--- a/articles.html
+++ b/articles.html
@@ -17,11 +17,9 @@
 <body>
     <nav class="site-nav">
         <a class="site-brand" href="index.html" aria-label="Matt McGinley Personal Training home">
-            <span class="site-brand__mark" aria-hidden="true"><span>MM</span></span>
-            <span class="site-brand__text">
-                <span class="site-brand__name">Matt McGinley</span>
-                <span class="site-brand__subtitle">Training</span>
-            </span>
+            <span class="site-brand__mark" aria-hidden="true">MM</span>
+            <span class="site-brand__divider" aria-hidden="true">|</span>
+            <span class="site-brand__name">Matt McGinley Training</span>
         </a>
         <button class="site-nav__toggle" type="button" aria-expanded="false" aria-controls="site-menu" aria-label="Open navigation menu">
             <span class="site-nav__hamburger" aria-hidden="true"></span>

--- a/begin.html
+++ b/begin.html
@@ -16,11 +16,9 @@
 <body>
     <nav class="site-nav">
         <a class="site-brand" href="index.html" aria-label="Matt McGinley Personal Training home">
-            <span class="site-brand__mark" aria-hidden="true"><span>MM</span></span>
-            <span class="site-brand__text">
-                <span class="site-brand__name">Matt McGinley</span>
-                <span class="site-brand__subtitle">Training</span>
-            </span>
+            <span class="site-brand__mark" aria-hidden="true">MM</span>
+            <span class="site-brand__divider" aria-hidden="true">|</span>
+            <span class="site-brand__name">Matt McGinley Training</span>
         </a>
         <button class="site-nav__toggle" type="button" aria-expanded="false" aria-controls="site-menu" aria-label="Open navigation menu">
             <span class="site-nav__hamburger" aria-hidden="true"></span>

--- a/calculators.html
+++ b/calculators.html
@@ -16,11 +16,9 @@
 <body>
     <nav class="site-nav">
         <a class="site-brand" href="index.html" aria-label="Matt McGinley Personal Training home">
-            <span class="site-brand__mark" aria-hidden="true"><span>MM</span></span>
-            <span class="site-brand__text">
-                <span class="site-brand__name">Matt McGinley</span>
-                <span class="site-brand__subtitle">Training</span>
-            </span>
+            <span class="site-brand__mark" aria-hidden="true">MM</span>
+            <span class="site-brand__divider" aria-hidden="true">|</span>
+            <span class="site-brand__name">Matt McGinley Training</span>
         </a>
         <button class="site-nav__toggle" type="button" aria-expanded="false" aria-controls="site-menu" aria-label="Open navigation menu">
             <span class="site-nav__hamburger" aria-hidden="true"></span>

--- a/css/style.css
+++ b/css/style.css
@@ -2630,3 +2630,106 @@ article {
         padding: clamp(1.25rem, 2vw, 1.55rem);
     }
 }
+
+/* --- 2026 dark performance redesign --- */
+:root {
+    --primary-color: #0057FF;
+    --primary-soft: #121722;
+    --cta-color: #0057FF;
+    --accent-color: #0057FF;
+    --accent-strong: #0057FF;
+    --surface-color: #121722;
+    --surface-muted: #121722;
+    --surface-tint: #121722;
+    --border-color: rgba(255, 255, 255, 0.08);
+    --text-color: #F5F7FA;
+    --shadow-soft: none;
+    --shadow-card: none;
+}
+
+body {
+    background: #05070B !important;
+    color: #F5F7FA;
+    line-height: 1.55;
+}
+
+h1, h2, h3, h4 { letter-spacing: -0.02em; color: #F5F7FA; }
+h1 strong, h2 strong, .section-label, .hero__eyebrow, .highlight, .text-accent { color: #0057FF !important; }
+p, li, td, th, label, small, .tagline { color: rgba(245, 247, 250, 0.86); }
+a { color: #F5F7FA; }
+a:hover, a:focus-visible { color: #0057FF; }
+
+section, article, .hero, .hero-card, .info-card, .service-card, .resource-card, .calculator-card,
+.blog-discovery, .featured-article, .article-nav__panel, .goal-quiz, .story-section, .cta-section,
+.site-nav, .testimonial, .pricing-card, .faq-item, .result-card, form {
+    background: #121722 !important;
+    border: 1px solid rgba(255, 255, 255, 0.08) !important;
+    border-radius: 6px !important;
+    box-shadow: none !important;
+    backdrop-filter: none !important;
+}
+
+section:hover, article:hover, .info-card:hover, .service-card:hover, .resource-card:hover, .featured-article:hover {
+    border-color: rgba(0, 87, 255, 0.7) !important;
+    box-shadow: 0 0 0 1px rgba(0, 87, 255, 0.45), 0 0 16px rgba(0, 87, 255, 0.18) !important;
+}
+
+.site-nav {
+    background: #05070B !important;
+    border: 0 !important;
+    border-bottom: 1px solid rgba(255,255,255,0.08) !important;
+    border-radius: 0 !important;
+    padding: 0.7rem 1rem !important;
+}
+.site-brand { display: flex; align-items: center; gap: 0.45rem; text-decoration: none; }
+.site-brand__mark, .site-brand__divider, .site-brand__name { color: #F5F7FA !important; font-weight: 700; }
+.site-brand__mark { font-size: 1rem; letter-spacing: 0.08em; }
+.site-brand__divider { color: #0057FF !important; opacity: 0.9; }
+.site-brand__name { font-size: 0.95rem; text-transform: uppercase; letter-spacing: 0.04em; }
+
+.site-nav__menu a {
+    border-radius: 4px !important;
+    padding: 0.45rem 0.6rem !important;
+    transition: color .2s ease, background-color .2s ease;
+}
+.site-nav__menu a:hover, .site-nav__menu a[aria-current='page'] {
+    color: #0057FF !important;
+    background: rgba(0, 87, 255, 0.12) !important;
+}
+.nav-icon svg { fill: currentColor !important; }
+
+button, .cta-button, .secondary-button, input[type='submit'] {
+    background: #0057FF !important;
+    color: #F5F7FA !important;
+    border: 1px solid #0057FF !important;
+    border-radius: 4px !important;
+    box-shadow: none !important;
+}
+button:hover, .cta-button:hover, .secondary-button:hover, input[type='submit']:hover {
+    filter: brightness(1.1);
+}
+
+img { border-radius: 4px !important; }
+.article-discovery-card__image, .featured-article__image, article > img {
+    object-fit: contain !important;
+    background: #05070B;
+}
+.article-discovery-card__media, .featured-article__media { position: relative; }
+.article-discovery-card__media::after, .featured-article__media::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: rgba(5,7,11,0);
+    transition: background .2s ease;
+}
+.article-discovery-card:hover .article-discovery-card__media::after,
+.featured-article:hover .featured-article__media::after {
+    background: rgba(5,7,11,0.2);
+}
+
+@media (max-width: 768px) {
+    body { font-size: 16px; }
+    .hero { padding: 1.4rem 0.8rem !important; }
+    section { margin: 1rem auto; padding: 0.85rem !important; }
+    .site-nav { padding: 0.6rem 0.75rem !important; }
+}

--- a/index.html
+++ b/index.html
@@ -17,11 +17,9 @@
 <body>
     <nav class="site-nav">
         <a class="site-brand" href="index.html" aria-label="Matt McGinley Personal Training home">
-            <span class="site-brand__mark" aria-hidden="true"><span>MM</span></span>
-            <span class="site-brand__text">
-                <span class="site-brand__name">Matt McGinley</span>
-                <span class="site-brand__subtitle">Training</span>
-            </span>
+            <span class="site-brand__mark" aria-hidden="true">MM</span>
+            <span class="site-brand__divider" aria-hidden="true">|</span>
+            <span class="site-brand__name">Matt McGinley Training</span>
         </a>
         <button class="site-nav__toggle" type="button" aria-expanded="false" aria-controls="site-menu" aria-label="Open navigation menu">
             <span class="site-nav__hamburger" aria-hidden="true"></span>

--- a/nutrition-calculator.html
+++ b/nutrition-calculator.html
@@ -272,11 +272,9 @@
 <body>
     <nav class="site-nav">
         <a class="site-brand" href="index.html" aria-label="Matt McGinley Personal Training home">
-            <span class="site-brand__mark" aria-hidden="true"><span>MM</span></span>
-            <span class="site-brand__text">
-                <span class="site-brand__name">Matt McGinley</span>
-                <span class="site-brand__subtitle">Training</span>
-            </span>
+            <span class="site-brand__mark" aria-hidden="true">MM</span>
+            <span class="site-brand__divider" aria-hidden="true">|</span>
+            <span class="site-brand__name">Matt McGinley Training</span>
         </a>
         <button class="site-nav__toggle" type="button" aria-expanded="false" aria-controls="site-menu" aria-label="Open navigation menu">
             <span class="site-nav__hamburger" aria-hidden="true"></span>

--- a/resources.html
+++ b/resources.html
@@ -17,11 +17,9 @@
 <body>
     <nav class="site-nav">
         <a class="site-brand" href="index.html" aria-label="Matt McGinley Personal Training home">
-            <span class="site-brand__mark" aria-hidden="true"><span>MM</span></span>
-            <span class="site-brand__text">
-                <span class="site-brand__name">Matt McGinley</span>
-                <span class="site-brand__subtitle">Training</span>
-            </span>
+            <span class="site-brand__mark" aria-hidden="true">MM</span>
+            <span class="site-brand__divider" aria-hidden="true">|</span>
+            <span class="site-brand__name">Matt McGinley Training</span>
         </a>
         <button class="site-nav__toggle" type="button" aria-expanded="false" aria-controls="site-menu" aria-label="Open navigation menu">
             <span class="site-nav__hamburger" aria-hidden="true"></span>

--- a/services.html
+++ b/services.html
@@ -16,11 +16,9 @@
 <body>
     <nav class="site-nav">
         <a class="site-brand" href="index.html" aria-label="Matt McGinley Personal Training home">
-            <span class="site-brand__mark" aria-hidden="true"><span>MM</span></span>
-            <span class="site-brand__text">
-                <span class="site-brand__name">Matt McGinley</span>
-                <span class="site-brand__subtitle">Training</span>
-            </span>
+            <span class="site-brand__mark" aria-hidden="true">MM</span>
+            <span class="site-brand__divider" aria-hidden="true">|</span>
+            <span class="site-brand__name">Matt McGinley Training</span>
         </a>
         <button class="site-nav__toggle" type="button" aria-expanded="false" aria-controls="site-menu" aria-label="Open navigation menu">
             <span class="site-nav__hamburger" aria-hidden="true"></span>

--- a/workout-generator.html
+++ b/workout-generator.html
@@ -13,11 +13,9 @@
 <body>
     <nav class="site-nav">
         <a class="site-brand" href="index.html" aria-label="Matt McGinley Personal Training home">
-            <span class="site-brand__mark" aria-hidden="true"><span>MM</span></span>
-            <span class="site-brand__text">
-                <span class="site-brand__name">Matt McGinley</span>
-                <span class="site-brand__subtitle">Training</span>
-            </span>
+            <span class="site-brand__mark" aria-hidden="true">MM</span>
+            <span class="site-brand__divider" aria-hidden="true">|</span>
+            <span class="site-brand__name">Matt McGinley Training</span>
         </a>
         <button class="site-nav__toggle" type="button" aria-expanded="false" aria-controls="site-menu" aria-label="Open navigation menu">
             <span class="site-nav__hamburger" aria-hidden="true"></span>


### PR DESCRIPTION
### Motivation
- Move the site to a premium, high-performance dark visual system using a strict 3-color palette (deep black `#05070B`, electric blue `#0057FF`, white `#F5F7FA`) and a single support shade `#121722` for surfaces and borders. 
- Remove the soft/pill/bubble visual language and warm/orange accents to create a compact, sharp, athletic look without altering content, layout, or functionality. 
- Improve hierarchy, contrast, and mobile density so the site reads as a high-end strength/performance brand while preserving existing routing and markup semantics. 

### Description
- Added a new global CSS override block in `css/style.css` that defines the new color tokens, forces deep-black page background, updates text colors, and replaces previous gradients/bright backgrounds with the dark palette. 
- Normalized cards/sections/containers to compact rectangular forms with `1px` low-contrast borders (`rgba(255,255,255,0.08)`), reduced radii, removed heavy shadows and glass effects, and added a subtle blue hover glow for emphasis. 
- Restyled interactive elements so blue (`#0057FF`) is used only for buttons, hover/active states, icons, and accent text, and buttons are flat blue with white text and tightened corners. 
- Preserved article imagery by applying `object-fit: contain` for preview images and added a subtle dark overlay on hover to keep images fully visible. 
- Updated the top-left brand markup across site pages to a minimalist text mark `MM | Matt McGinley Training` (visual-only change to header text markup) while keeping navigation structure and links intact. 
- Applied mobile-first spacing and type tweaks to reduce vertical spacing and tighten the visual rhythm on small screens. 

### Testing
- No automated test suite is configured for this project, so no automated tests were run against these style/markup-only changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02406d7a3c8326879be5a1a46c3790)