### PR TITLE
Add free Workout Generator callout to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,6 +105,19 @@
         </div>
     </section>
 
+
+    <section class="intro-section">
+        <div class="intro-section__content">
+            <p class="section-label">Free tool</p>
+            <h2>Try the Free Workout Generator</h2>
+            <p>Answer a few questions and get a structured 6-week plan based on your goal, schedule, equipment, and strength level.</p>
+            <div class="hero-actions">
+                <a class="cta-button" href="workout-generator.html">Build My Plan</a>
+            </div>
+            <p>This gives you something interactive to test before you apply for coaching.</p>
+        </div>
+    </section>
+
     <section class="story-section">
         <p class="section-label">Why me</p>
         <h2>I've lived the transformation</h2>


### PR DESCRIPTION
### Motivation
- Promote the existing interactive Workout Generator on the homepage so visitors can try a free 6-week plan before applying for coaching.

### Description
- Inserted a new `section` in `index.html` (positioned before the story section) with the headline “Try the Free Workout Generator”, supporting copy, and a primary CTA button linking to `workout-generator.html` (`<a class="cta-button" href="workout-generator.html">Build My Plan</a>`).

### Testing
- No automated tests are configured for this static site.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a078d5828fc8326a67c8f0b1ec4c6f2)