### PR TITLE
Remove hero preview and darken summary/form cards

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2230,6 +2230,29 @@ nav a[aria-current="page"] {
     margin-bottom: 0;
 }
 
+.strength-card,
+.live-summary-card,
+.qualifier-card,
+.adaptation-note {
+    background: linear-gradient(165deg, rgba(8, 20, 40, 0.96), rgba(5, 14, 30, 0.98));
+    border: 1px solid rgba(124, 161, 206, 0.3);
+    color: var(--text-secondary);
+}
+
+.strength-card h3,
+.live-summary-card strong,
+.qualifier-card h3 {
+    color: var(--text-primary);
+}
+
+.live-summary-card p,
+.qualifier-card p,
+.estimate-note,
+.adaptation-note,
+.field-note {
+    color: rgba(245, 247, 250, 0.82);
+}
+
 .program-hero-card {
     margin-bottom: 1rem;
     border-radius: 20px;

--- a/workout-generator.html
+++ b/workout-generator.html
@@ -48,28 +48,7 @@
                     <li>Clear daily structure you can run immediately</li>
                 </ul>
             </div>
-            <aside class="hero-preview" aria-label="Sample output preview">
-                <h2>What you’ll receive</h2>
-                <div class="preview-stack" aria-hidden="true">
-                    <article class="preview-card preview-card--overview">
-                        <p class="preview-label">Coaching overview</p>
-                        <h3>4-day Intermediate Powerbuilding</h3>
-                        <p>Full-gym sessions · Shoulder-friendly swaps · Chest priority</p>
-                    </article>
-                    <article class="preview-card preview-card--table">
-                        <p class="preview-label">Week 1–6 progression</p>
-                        <div class="preview-table-lines"></div>
-                    </article>
-                    <article class="preview-card preview-card--day">
-                        <p class="preview-label">Sample training day</p>
-                        <ul>
-                            <li>Main lift: Bench press progression</li>
-                            <li>Accessory block: Row / incline press / delts</li>
-                            <li>Execution standards + rest guidance</li>
-                        </ul>
-                    </article>
-                </div>
-            </aside>
+            
         </div>
     </header>
 


### PR DESCRIPTION
### Motivation
- The hero "What you’ll receive" preview shows placeholder/mock output before a user builds a plan and can be confusing, so the hero should start clean with the main headline and flow.  
- The strength inputs and summary sections used white backgrounds that clash with the site’s dark reskin, so they need to match the rest of the UI and improve text contrast.

### Description
- Removed the hero preview block (the `<aside class="hero-preview">` sample output) from `workout-generator.html` so the page no longer shows the placeholder preview at the top.  
- Added scoped dark-surface styles to `css/style.css` for `.strength-card`, `.live-summary-card`, `.qualifier-card`, and `.adaptation-note` to use a dark gradient, blue-accent border, and site color variables.  
- Adjusted heading/strong and supporting text color rules so labels and explanatory copy are readable against the darker surfaces.

### Testing
- Ran `git diff -- workout-generator.html css/style.css` to verify the file changes and diff contents, which reported the intended deletions and insertions.  
- Started a local static server with `python -m http.server 4173` to preview the updated page successfully.  
- Attempted a Playwright screenshot using `npx --yes playwright@1.54.2 screenshot --device="iPhone 14" http://127.0.0.1:4173/workout-generator.html /tmp/workout-generator-updated.png`, but it failed due to npm registry access restrictions (`403 Forbidden`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a078ee531d88326a5a012a8d889c0ce)