### PR TITLE
Improve program hero readability and lock strength progression to 5x5

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2528,6 +2528,26 @@ nav a[aria-current="page"] {
     color: var(--text-primary);
 }
 
+
+.program-hero-card__standards,
+.program-hero-card__notes {
+    background: rgba(15, 23, 42, 0.78);
+    border-color: rgba(148, 163, 184, 0.45);
+}
+
+.program-hero-card__standards h4,
+.program-hero-card__notes h4,
+.program-hero-card__standards ul,
+.program-hero-card__notes ul {
+    color: #e2e8f0;
+}
+
+.program-hero-card__chips span {
+    background: rgba(255, 255, 255, 0.08);
+    color: #e2e8f0;
+    border-color: rgba(148, 163, 184, 0.4);
+}
+
 /* ===== Compact card density refresh ===== */
 :root {
     --section-gap: clamp(1.2rem, 3.2vw, 2.3rem);

--- a/js/workout-generator.js
+++ b/js/workout-generator.js
@@ -33,12 +33,12 @@
 
     var weekPresets = {
         strength: [
-            { pct: 0.7, sets: 4, reps: 6, note: 'Linear progression start' },
-            { pct: 0.72, sets: 4, reps: 6, note: 'Add load with clean reps' },
-            { pct: 0.74, sets: 4, reps: 5, note: 'Steady progression' },
-            { pct: 0.76, sets: 5, reps: 4, note: 'Progressive overload' },
-            { pct: 0.78, sets: 5, reps: 4, note: 'Heavy, controlled reps' },
-            { pct: 0.8, sets: 5, reps: 3, note: 'Top week' }
+            { pct: 0.7, sets: 5, reps: 5, note: 'Linear progression start' },
+            { pct: 0.72, sets: 5, reps: 5, note: 'Add load with clean reps' },
+            { pct: 0.74, sets: 5, reps: 5, note: 'Steady progression' },
+            { pct: 0.76, sets: 5, reps: 5, note: 'Progressive overload' },
+            { pct: 0.78, sets: 5, reps: 5, note: 'Heavy, controlled reps' },
+            { pct: 0.8, sets: 5, reps: 5, note: 'Top week' }
         ],
         hypertrophy: [
             { pct: 0.7, sets: 4, reps: 8, note: 'Linear progression start' },


### PR DESCRIPTION
### Motivation
- Program hero text and chips were low-contrast in the final theme and hard to read on generated program results. 
- Strength-style progressions were tapering reps across weeks, but the plan should keep main lifts at a 5×5 template for all six weeks when `strength` is selected.

### Description
- Added high-contrast CSS overrides for the generated program hero blocks by styling `.program-hero-card__standards`, `.program-hero-card__notes`, and the chip spans to ensure readable text in the final/dark theme in `css/style.css`.
- Changed the `strength` preset in `weekPresets` inside `js/workout-generator.js` so all six strength weeks use `sets: 5` and `reps: 5` while retaining progressive percentages (`pct`).
- The changes are scoped to the program display styling and the strength progression preset only.

### Testing
- Verified the updated `weekPresets` block via file inspection of `js/workout-generator.js` and confirmed the `strength` preset now lists six `5x5` entries (success).
- Verified the new CSS rules were inserted into `css/style.css` and printed the block to confirm color and background values (success).
- Performed a repository-wide search to ensure the modifications only affected `js/workout-generator.js` and `css/style.css` (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14c089ca74832693a7ac75f4fb9873)