### PR TITLE
Add obesity article image

### DIFF
--- a/articles.html
+++ b/articles.html
@@ -80,7 +80,7 @@
             </div>
         </nav>
         <article id="why-everyone-became-overweight">
-            <img src="PersonalTrainingAILogo.jpeg" alt="Why Everyone Became Overweight article image">
+            <img src="B367BE7D-7488-498A-8DED-95CB3B0B7AD6.png" alt="Built for scarcity. Living in abundance. article image">
             <h2>Why Everyone Became Overweight</h2>
             <p>For most of human history, the biggest food problem was not self-control. It was access.</p>
             <p>Humans evolved in a world where food was uncertain, calories were hard to get, and survival often depended on taking advantage of food whenever it was available. If you found something calorie-dense, your body wanted you to eat it. That was not a flaw. That was the system working exactly as designed.</p>


### PR DESCRIPTION
### Motivation
- Replace the placeholder image in the obesity article with the intended PNG asset to improve the article's visual and accessibility metadata.

### Description
- Update `articles.html` to replace the image for the article with `id="why-everyone-became-overweight"` to use `B367BE7D-7488-498A-8DED-95CB3B0B7AD6.png` and set the alt text to "Built for scarcity. Living in abundance. article image".

### Testing
- Ran a Python check that asserted the new asset is referenced in `articles.html` and that `B367BE7D-7488-498A-8DED-95CB3B0B7AD6.png` exists on disk, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a419c45f7b88326ab3e37df9ff8af4d)