### PR TITLE
Add home page story photo

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -296,6 +296,26 @@ section {
     background: transparent;
 }
 
+.story-photo {
+    max-width: 520px;
+    margin: 1.5rem auto 2rem;
+    overflow: hidden;
+    border-radius: 24px;
+    border: 1px solid rgba(121, 152, 255, 0.24);
+    background: rgba(18, 23, 34, 0.9);
+    box-shadow: 0 22px 44px rgba(0, 0, 0, 0.36);
+}
+
+.story-photo img {
+    max-width: none;
+    width: 100%;
+    aspect-ratio: 4 / 3;
+    object-fit: cover;
+    object-position: 50% 30%;
+    border-radius: 0;
+    box-shadow: none;
+}
+
 .story-section__intro {
     display: grid;
     gap: 1.5rem;

--- a/index.html
+++ b/index.html
@@ -121,6 +121,9 @@
     <section class="story-section">
         <p class="section-label">Why me</p>
         <h2>I've lived the transformation</h2>
+        <figure class="story-photo">
+            <img src="IMG_3785.jpeg" alt="Matt McGinley showing the physique built through consistent training">
+        </figure>
         <p>My life has always revolved around health and fitness. I grew up loving sports, and then it was taken away from me when I was in high school due to an extreme case of Osgood-Schlatter's disease. My knee was effectively shattered into many pieces and I spent 3 years on and off in a full leg cast all throughout high school.</p>
         <p>I didn't understand health or nutrition, so I became out of shape. I couldn't exercise and I didn't understand how to eat right. It wasn't something I was ever taught.</p>
         <p>Eventually, my doctor told me that my knee can't get any worse, so it's either I figure out a way to deal with the pain and fix it or get a screw placed in my knee through surgery. That moment I committed to doing whatever it took to get better.</p>


### PR DESCRIPTION
### Motivation
- Improve the home page by adding a visual to the “Why me” / transformation story so visitors immediately see the trainer’s results. 
- Ensure the new image integrates with the site’s dark card aesthetic and crops consistently across viewports.

### Description
- Inserted a `<figure class="story-photo">` containing `IMG_3785.jpeg` with descriptive `alt` text into the `story-section` before the first paragraph. 
- Added `.story-photo` and `.story-photo img` rules to `css/style.css` to constrain width, provide a dark rounded card background, and set a 4:3 crop with `object-fit: cover` and `object-position: 50% 30%`. 
- Placed the markup so the image appears above the narrative copy in the transformation section and matches existing spacing and typography.

### Testing
- Parsed `index.html` with Python’s `HTMLParser` to validate the produced HTML and the new `<figure>` element, and the parse completed successfully. 
- Ran `git diff --check` to validate whitespace and basic diff errors and it reported no issues. 
- Served the site with `python3 -m http.server` and confirmed `curl -I http://127.0.0.1:4173/index.html` returned `200 OK`. 
- Verified the page contains the new image and class using `curl -s http://127.0.0.1:4173/index.html | rg -n "story-photo|IMG_3785"` which found the inserted lines. 
- Attempted to capture a browser screenshot via `npx playwright` but the Playwright install failed due to an npm registry `403 Forbidden` error, so screenshot automation was not run successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a504d6b24a88326ae335368b4c63f88)