### PR TITLE
Replace home hero image with IMG_3785.jpeg

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@
             </div>
             <div class="hero__visual">
                 <div class="hero-card">
-                    <img src="MeFlexing3.jpg" alt="Matt McGinley flexing after a training session">
+                    <img src="IMG_3785.jpeg" alt="Matt McGinley showing the physique built through consistent training">
                     <div class="hero-card__body">
                         <p class="hero-card__label">What you get</p>
                         <ul class="hero-card__list">


### PR DESCRIPTION
### Motivation
- Feature the provided photo prominently on the home page hero to better illustrate the coaching transformation using `IMG_3785.jpeg`.

### Description
- Updated `index.html` to replace the hero image `MeFlexing3.jpg` with `IMG_3785.jpeg` and adjusted the `alt` text to match the coaching story.

### Testing
- Ran `git diff --check`, served the site with `python3 -m http.server`, and verified `GET /`, `GET /IMG_3785.jpeg`, and `GET /css/style.css` via a small `urlopen` script which returned `200` responses and correct `Content-Type`, and confirmed the image is a JPEG via `imghdr`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50521a9d0883269dc870f91a45ea3d)