### PR TITLE
Unify interior page styling with homepage

### DIFF
--- a/about.html
+++ b/about.html
@@ -13,7 +13,7 @@
     <link rel="stylesheet" href="css/style.css">
 </head>
 
-<body>
+<body class="interior-page">
     <nav class="site-nav">
         <a class="site-brand" href="index.html" aria-label="Matt McGinley Personal Training home">
             <span class="site-brand__mark" aria-hidden="true"><span>MM</span></span>
@@ -37,7 +37,7 @@
                 <li><a href="begin.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="m8.25 5.25 9 6.75-9 6.75z"/></svg></span><span>Begin</span></a></li>
         </ul>
     </nav>
-    <header class="hero">
+    <header class="hero page-hero">
         <h1>About Me</h1>
         <p class="tagline">Lose fat, gain muscle, live pain-free.</p>
         <aside><a class="emailIG" href="mailto:matthewmcginley@live.com">matthewmcginley@live.com</a> | <a class="emailIG"

--- a/articles.html
+++ b/articles.html
@@ -14,7 +14,7 @@
     <title>Articles - Matt McGinley Personal Training</title>
     <link rel="stylesheet" href="css/style.css">
 </head>
-<body>
+<body class="interior-page">
     <nav class="site-nav">
         <a class="site-brand" href="index.html" aria-label="Matt McGinley Personal Training home">
             <span class="site-brand__mark" aria-hidden="true"><span>MM</span></span>
@@ -38,7 +38,7 @@
                 <li><a href="begin.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="m8.25 5.25 9 6.75-9 6.75z"/></svg></span><span>Begin</span></a></li>
         </ul>
     </nav>
-    <header class="hero">
+    <header class="hero page-hero">
         <h1>Articles</h1>
         <p class="tagline">Thoughts on training and nutrition</p>
         <aside><a class="emailIG" href="mailto:matthewmcginley@live.com">matthewmcginley@live.com</a> |

--- a/begin.html
+++ b/begin.html
@@ -13,7 +13,7 @@
     <link rel="stylesheet" href="css/style.css">
 </head>
 
-<body>
+<body class="interior-page">
     <nav class="site-nav">
         <a class="site-brand" href="index.html" aria-label="Matt McGinley Personal Training home">
             <span class="site-brand__mark" aria-hidden="true"><span>MM</span></span>
@@ -38,7 +38,7 @@
         </ul>
     </nav>
 
-    <header class="hero">
+    <header class="hero page-hero">
         <h1>Let's Start!!</h1>
         <p class="tagline">Lose fat, gain muscle, live pain-free</p>
         <aside><a class="emailIG" href="mailto:matthewmcginley@live.com">matthewmcginley@live.com</a> | <a class="emailIG" href="https://www.instagram.com/mattmcginley7"> Instagram</a></aside>

--- a/calculators.html
+++ b/calculators.html
@@ -13,7 +13,7 @@
     <link rel="stylesheet" href="css/style.css">
 </head>
 
-<body>
+<body class="interior-page">
     <nav class="site-nav">
         <a class="site-brand" href="index.html" aria-label="Matt McGinley Personal Training home">
             <span class="site-brand__mark" aria-hidden="true"><span>MM</span></span>
@@ -37,7 +37,7 @@
                 <li><a href="begin.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="m8.25 5.25 9 6.75-9 6.75z"/></svg></span><span>Begin</span></a></li>
         </ul>
     </nav>
-    <header class="hero">
+    <header class="hero page-hero">
         <h1>Calculators</h1>
         <p class="tagline">Lose fat, gain muscle, live pain-free</p>
         <aside><a class="emailIG" href="mailto:matthewmcginley@live.com">matthewmcginley@live.com</a> |

--- a/css/style.css
+++ b/css/style.css
@@ -2990,3 +2990,196 @@ iframe { border: 1px solid var(--border-color); border-radius: 9px; box-shadow: 
 @media (min-width: 900px) {
     body, .site-nav, .hero, section { max-width: 760px; }
 }
+
+/* ===== Site-wide page polish: align interior pages with front-page aesthetic ===== */
+.page-hero {
+    min-height: clamp(260px, 36vh, 390px);
+    display: grid;
+    place-items: center;
+    text-align: center;
+    padding: clamp(2rem, 6vw, 4.75rem) 1rem;
+}
+
+.page-hero h1 {
+    margin: 0;
+    font-size: clamp(2.45rem, 8vw, 5.6rem);
+    line-height: 0.95;
+    letter-spacing: -0.065em;
+}
+
+.page-hero .tagline {
+    max-width: 44rem;
+    margin: 1rem auto 0;
+}
+
+.page-hero aside {
+    margin-top: 1.2rem;
+}
+
+section:not(.hero):not(.article-nav):not(.qualifier-card) {
+    width: min(100% - 2rem, 980px);
+}
+
+body.interior-page > section,
+.calculator-section,
+.resources-section,
+.article-section {
+    margin-top: clamp(1.2rem, 3vw, 2.2rem);
+}
+
+body.interior-page > section:not(.calculator-section):not(.resources-section):not(.article-section),
+.calculator-card,
+.resource-card,
+.article-section article[id],
+.blog-discovery,
+.featured-article-card,
+.article-card,
+.start-here-card {
+    border: 1px solid rgba(121, 152, 255, 0.24);
+    border-radius: 22px;
+    background: linear-gradient(160deg, rgba(14, 35, 66, 0.94), rgba(8, 22, 43, 0.97));
+    box-shadow: var(--shadow-deep);
+}
+
+body.interior-page > section:not(.calculator-section):not(.resources-section):not(.article-section) {
+    padding: clamp(1.25rem, 3vw, 2rem);
+}
+
+.calculator-section,
+.resources-section,
+.article-section {
+    padding: 0;
+    background: transparent;
+    border: 0;
+    box-shadow: none;
+}
+
+.calculator-card,
+.resource-card,
+.article-section article[id],
+.blog-discovery {
+    padding: clamp(1rem, 2.4vw, 1.55rem);
+    margin-bottom: 1rem;
+}
+
+.article-section article[id] {
+    font-family: 'Outfit', 'Roboto', sans-serif;
+    line-height: 1.72;
+    scroll-margin-top: 5rem;
+}
+
+.article-section article[id] h2,
+.article-section article[id] h3,
+.article-section article[id] h4,
+.calculator-card h2,
+.calculator-card h3,
+.resource-card h2,
+.resource-card h3 {
+    color: var(--text-primary);
+}
+
+.featured-article-card,
+.article-card {
+    overflow: hidden;
+}
+
+.featured-article-card img,
+.article-card__image-wrap img {
+    background: rgba(5, 17, 34, 0.7);
+}
+
+.article-card__body,
+.featured-article-card__content {
+    background: transparent;
+}
+
+.blog-filter {
+    min-width: auto;
+    min-height: 0;
+    height: auto;
+    color: var(--text-primary);
+    box-shadow: none;
+}
+
+.blog-filter.is-active {
+    background: rgba(0, 87, 255, 0.32);
+    color: #fff;
+}
+
+.article-note,
+.adaptation-note,
+.live-summary-card,
+.qualifier-card,
+.strength-card,
+.program-hero-card,
+.program-hero-card__standards,
+.program-hero-card__notes,
+.workout-form,
+.workout-preview,
+.program-card,
+.program-summary-card,
+.workout-cta-card,
+.hero-preview,
+.preview-card,
+.workout-fieldset {
+    background: linear-gradient(160deg, rgba(14, 35, 66, 0.94), rgba(8, 22, 43, 0.97));
+    border-color: rgba(121, 152, 255, 0.24);
+    color: var(--text-secondary);
+}
+
+.workout-trust-pill,
+.step-label,
+.program-hero-card__eyebrow,
+.program-hero-card__intro,
+.program-summary-note,
+.preview-label,
+.preview-card p,
+.program-hero-card ul,
+.substitution-list,
+.workout-submit-note,
+.rest-note {
+    color: var(--text-secondary);
+}
+
+.secondary-button,
+.day-tab-button {
+    background: rgba(5, 18, 38, 0.9);
+    border-color: rgba(0, 87, 255, 0.75);
+    color: #F5F7FA;
+}
+
+.table-wrap th,
+.table-wrap td {
+    border-color: rgba(130, 165, 207, 0.4);
+}
+
+.table-wrap th {
+    background: rgba(0, 87, 255, 0.2);
+    color: #F5F7FA;
+}
+
+@media (min-width: 768px) {
+    body.interior-page > section:not(.calculator-section):not(.resources-section):not(.article-section) {
+        column-count: 1;
+    }
+}
+
+@media (max-width: 760px) {
+    .page-hero {
+        min-height: auto;
+        text-align: left;
+        place-items: start;
+    }
+
+    .page-hero h1,
+    .page-hero .tagline,
+    .page-hero aside {
+        text-align: left;
+        margin-left: 0;
+        margin-right: 0;
+    }
+
+    section:not(.hero):not(.article-nav):not(.qualifier-card) {
+        width: min(100% - 1.2rem, 980px);
+    }
+}

--- a/resources.html
+++ b/resources.html
@@ -14,7 +14,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="css/style.css">
 </head>
-<body>
+<body class="interior-page">
     <nav class="site-nav">
         <a class="site-brand" href="index.html" aria-label="Matt McGinley Personal Training home">
             <span class="site-brand__mark" aria-hidden="true"><span>MM</span></span>
@@ -38,7 +38,7 @@
                 <li><a href="begin.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="m8.25 5.25 9 6.75-9 6.75z"/></svg></span><span>Begin</span></a></li>
         </ul>
     </nav>
-    <header class="hero">
+    <header class="hero page-hero">
         <h1>Resources</h1>
         <p class="tagline">Lose fat, gain muscle, live pain-free</p>
         <aside><a class="emailIG" href="mailto:matthewmcginley@live.com">matthewmcginley@live.com</a> |

--- a/services.html
+++ b/services.html
@@ -13,7 +13,7 @@
     <link rel="stylesheet" href="css/style.css">
 </head>
 
-<body>
+<body class="interior-page">
     <nav class="site-nav">
         <a class="site-brand" href="index.html" aria-label="Matt McGinley Personal Training home">
             <span class="site-brand__mark" aria-hidden="true"><span>MM</span></span>
@@ -37,7 +37,7 @@
                 <li><a href="begin.html"><span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="m8.25 5.25 9 6.75-9 6.75z"/></svg></span><span>Begin</span></a></li>
         </ul>
     </nav>
-    <header class="hero">
+    <header class="hero page-hero">
         <h1>Services</h1>
         <p class="tagline">Lose fat, gain muscle, live pain-free</p>
         <aside><a class="emailIG" href="mailto:matthewmcginley@live.com">matthewmcginley@live.com</a> |


### PR DESCRIPTION
### Motivation
- Secondary pages used lighter, compact or inconsistent styling compared with the homepage hero and card aesthetic, producing a fragmented site look.  
- The goal is to give interior pages the same dark, elevated hero and card treatments so visual language is consistent across the site.

### Description
- Added a page-level CSS section in `css/style.css` that implements a `.page-hero` layout and a set of interior-page rules to apply the homepage dark hero, card, and component treatments across pages.  
- Marked standard interior pages with `class="interior-page"` on `<body>` and added `class="page-hero"` to their top `<header class="hero">` so they receive the new styling; applied to `about.html`, `articles.html`, `begin.html`, `calculators.html`, `resources.html`, and `services.html`.  
- Extended the dark card look and typography to calculators, resource cards, article cards, featured article areas, workout cards, and related components so interior sections match the homepage color/tint/shadow system.  
- Added responsive rules so desktop pages show a compact centered hero while mobile keeps readable left-aligned layout and preserved accessibility hints.

### Testing
- Ran `git diff --check` to validate whitespace/patch issues and it returned clean.  
- Performed an HTML parse smoke-check with `python3` using `html.parser` against all root HTML files to ensure pages remain syntactically valid and it succeeded.  
- Started a local `python3 -m http.server` and attempted a Playwright screenshot to visually verify a page, but Playwright is not available in the environment so screenshot capture could not run (Playwright failure reported).  
- Verified modified files: `css/style.css`, `about.html`, `articles.html`, `begin.html`, `calculators.html`, `resources.html`, and `services.html` and confirmed the new classes/selectors are present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52b7097ec08326a3deb22c9dbd9d8c)