### PR TITLE
Redesign articles page navigation

### DIFF
--- a/articles.html
+++ b/articles.html
@@ -14,7 +14,7 @@
     <title>Articles - Matt McGinley Personal Training</title>
     <link rel="stylesheet" href="css/style.css">
 </head>
-<body class="interior-page">
+<body class="interior-page articles-page">
     <nav class="site-nav">
         <a class="site-brand" href="index.html" aria-label="Matt McGinley Personal Training home">
             <span class="site-brand__mark" aria-hidden="true"><span>MM</span></span>
@@ -40,24 +40,31 @@
     </nav>
     <header class="hero page-hero">
         <h1>Articles</h1>
-        <p class="tagline">Thoughts on training and nutrition</p>
+        <p class="tagline">A searchable training library for fat loss, strength, muscle, nutrition, and mindset.</p>
         <aside><a class="emailIG" href="mailto:matthewmcginley@live.com">matthewmcginley@live.com</a> |
             <a class="emailIG" href="https://www.instagram.com/mattmcginley7"> Instagram</a></aside>
     </header>
     <section class="article-section">
         <section class="blog-discovery" aria-labelledby="blogDiscoveryHeading">
             <div class="blog-discovery__intro">
-                <h2 id="blogDiscoveryHeading">Featured article</h2>
-                <p>Latest coaching insight from Matt.</p>
+                <p class="section-label">Training library</p>
+                <h2 id="blogDiscoveryHeading">Find the article you need fast</h2>
+                <p>Use the search, topic filters, or article cards below to jump directly to any full article on the page.</p>
+            </div>
+            <div class="blog-discovery__tools" aria-label="Article discovery tools">
+                <label class="article-search" for="articleSearchInput">
+                    <span>Search articles</span>
+                    <input id="articleSearchInput" type="search" placeholder="Search fat loss, bench press, caffeine…" autocomplete="off">
+                </label>
+                <div class="blog-filters" aria-label="Filter articles by topic">
+                    <h3>Browse by topic</h3>
+                    <div class="blog-filters__buttons" id="blogFilterButtons">
+                        <button type="button" class="blog-filter is-active" data-topic="all" aria-pressed="true">All topics</button>
+                    </div>
+                </div>
             </div>
             <div class="featured-article-spotlight" id="featuredArticleSpotlight">
                 <p class="article-nav__empty">Loading featured article…</p>
-            </div>
-            <div class="blog-filters" aria-label="Filter articles by topic">
-                <h3>Browse by topic</h3>
-                <div class="blog-filters__buttons" id="blogFilterButtons">
-                    <button type="button" class="blog-filter is-active" data-topic="all" aria-pressed="true">All topics</button>
-                </div>
             </div>
             <div class="article-discovery-grid" id="articleDiscoveryGrid" aria-live="polite">
                 <p class="article-nav__empty">Loading article previews…</p>

--- a/css/style.css
+++ b/css/style.css
@@ -3183,3 +3183,210 @@ body.interior-page > section:not(.calculator-section):not(.resources-section):no
         width: min(100% - 1.2rem, 980px);
     }
 }
+
+/* ===== Articles page navigation redesign ===== */
+.articles-page .article-section {
+    width: min(100% - 2rem, 1120px);
+}
+
+.articles-page .blog-discovery {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    gap: clamp(1rem, 2.5vw, 1.4rem);
+    padding: clamp(1rem, 3vw, 1.65rem);
+    position: relative;
+    overflow: hidden;
+}
+
+.articles-page .blog-discovery::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background:
+        radial-gradient(circle at 15% 0%, rgba(240, 173, 56, 0.16), transparent 30%),
+        linear-gradient(135deg, rgba(255,255,255,0.04), transparent 45%);
+    pointer-events: none;
+}
+
+.articles-page .blog-discovery > * {
+    position: relative;
+    z-index: 1;
+}
+
+.articles-page .blog-discovery__intro {
+    max-width: 720px;
+}
+
+.articles-page .blog-discovery__intro p:not(.section-label) {
+    margin: 0;
+    max-width: 58ch;
+}
+
+.articles-page .blog-discovery__tools {
+    display: grid;
+    gap: 1rem;
+    align-items: end;
+}
+
+.articles-page .article-search {
+    display: grid;
+    gap: 0.45rem;
+    font-weight: 900;
+    text-transform: uppercase;
+    letter-spacing: 0.055em;
+    color: var(--accent-color);
+}
+
+.articles-page .article-search input {
+    width: 100%;
+    min-height: 3rem;
+    font-size: 1rem;
+    text-transform: none;
+    letter-spacing: 0;
+}
+
+.articles-page .blog-filters {
+    margin: 0;
+}
+
+.articles-page .blog-filters h3 {
+    margin-bottom: 0.6rem;
+    color: var(--accent-color);
+    text-transform: uppercase;
+    letter-spacing: 0.055em;
+}
+
+.articles-page .blog-filters__buttons {
+    margin: 0;
+}
+
+.articles-page .blog-filter {
+    width: auto;
+    min-height: 2.25rem;
+    padding: 0.55rem 0.75rem;
+}
+
+.articles-page .featured-article-spotlight {
+    margin: 0;
+}
+
+.articles-page .featured-article-card {
+    display: grid;
+    grid-template-columns: minmax(150px, 0.42fr) minmax(0, 0.58fr);
+    align-items: stretch;
+    min-height: 230px;
+}
+
+.articles-page .featured-article-card img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover !important;
+    border-radius: 0;
+}
+
+.articles-page .featured-article-card__content {
+    display: grid;
+    align-content: center;
+    gap: 0.6rem;
+    padding: clamp(1rem, 3vw, 1.5rem);
+}
+
+.articles-page .featured-article-card__content::before {
+    content: "Newest article";
+    color: var(--accent-color);
+    font-size: 0.72rem;
+    font-weight: 900;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.articles-page .article-discovery-grid {
+    grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+    align-items: stretch;
+}
+
+.articles-page .article-card,
+.articles-page .article-card__link {
+    height: 100%;
+}
+
+.articles-page .article-card__link {
+    display: grid;
+    grid-template-rows: 145px 1fr;
+}
+
+.articles-page .article-card__image-wrap {
+    overflow: hidden;
+}
+
+.articles-page .article-card__image-wrap img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover !important;
+    transition: transform 0.18s ease, filter 0.18s ease;
+}
+
+.articles-page .article-card__body {
+    display: grid;
+    gap: 0.55rem;
+    align-content: start;
+    padding: 0.95rem;
+}
+
+.articles-page .article-card h3 {
+    font-size: 1.08rem;
+    line-height: 1.12;
+}
+
+.articles-page .article-card__excerpt {
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    margin: 0;
+}
+
+.articles-page .article-card__cta {
+    margin-top: auto;
+    color: var(--accent-color);
+    font-weight: 900;
+    text-transform: uppercase;
+    letter-spacing: 0.055em;
+}
+
+.articles-page .article-card__link:hover img,
+.articles-page .article-card__link:focus img {
+    transform: scale(1.04);
+    filter: brightness(1.1);
+}
+
+.articles-page .article-nav__empty--wide {
+    grid-column: 1 / -1;
+    padding: 1rem;
+    border: 1px dashed var(--border-color);
+    border-radius: 9px;
+}
+
+.articles-page .article-section article[id] {
+    margin-top: 1rem;
+}
+
+@media (min-width: 780px) {
+    .articles-page .blog-discovery__tools {
+        grid-template-columns: minmax(260px, 0.42fr) minmax(0, 0.58fr);
+    }
+}
+
+@media (max-width: 680px) {
+    .articles-page .featured-article-card {
+        grid-template-columns: 1fr;
+    }
+
+    .articles-page .featured-article-card img {
+        height: 190px;
+    }
+
+    .articles-page .article-card__link {
+        grid-template-rows: 175px 1fr;
+    }
+}

--- a/js/main.js
+++ b/js/main.js
@@ -302,6 +302,7 @@ document.addEventListener('DOMContentLoaded', function () {
     var featuredArticleSpotlight = document.querySelector('#featuredArticleSpotlight');
     var articleDiscoveryGrid = document.querySelector('#articleDiscoveryGrid');
     var blogFilterButtons = document.querySelector('#blogFilterButtons');
+    var articleSearchInput = document.querySelector('#articleSearchInput');
 
     var articleMetaConfig = {
         'day-one-start-lifting': { topic: 'Beginner training', date: '2026-01-03', startHere: true },
@@ -422,18 +423,29 @@ document.addEventListener('DOMContentLoaded', function () {
                 });
             }
 
+            var activeArticleTopic = 'all';
+
             var renderDiscoveryCards = function (activeTopic) {
+                activeArticleTopic = activeTopic || activeArticleTopic || 'all';
+                var searchTerm = articleSearchInput ? articleSearchInput.value.trim().toLowerCase() : '';
                 articleDiscoveryGrid.innerHTML = '';
                 var filteredCards = articleCards.filter(function (card) {
-                    return activeTopic === 'all' || card.topic.toLowerCase() === activeTopic;
+                    var matchesTopic = activeArticleTopic === 'all' || card.topic.toLowerCase() === activeArticleTopic;
+                    var searchableText = [card.title, card.topic, card.excerpt].join(' ').toLowerCase();
+                    var matchesSearch = !searchTerm || searchableText.indexOf(searchTerm) !== -1;
+                    return matchesTopic && matchesSearch;
                 });
+
+                if (!filteredCards.length) {
+                    articleDiscoveryGrid.innerHTML = '<p class="article-nav__empty article-nav__empty--wide">No articles match that search. Try another topic or keyword.</p>';
+                }
 
                 filteredCards.forEach(function (card) {
                     var cardArticle = document.createElement('article');
                     cardArticle.className = 'article-card';
                     cardArticle.innerHTML = '<a class="article-card__link" href="#' + card.id + '"><div class="article-card__image-wrap"><img src="' + card.image + '" alt="' + card.imageAlt + '" loading="lazy"></div>'
-                        + '<div class="article-card__body"><h3>' + card.title + '</h3>'
-                        + '<p class="article-card__meta">' + card.topic + ' • ' + prettyDate(card.date) + ' • ' + card.readTime + ' min read</p></div></a>';
+                        + '<div class="article-card__body"><p class="article-card__meta">' + card.topic + ' • ' + prettyDate(card.date) + ' • ' + card.readTime + ' min read</p>'
+                        + '<h3>' + card.title + '</h3><p class="article-card__excerpt">' + card.excerpt + '</p><span class="article-card__cta">Read article</span></div></a>';
                     articleDiscoveryGrid.appendChild(cardArticle);
 
                     var articleNode = document.getElementById(card.id);
@@ -448,7 +460,9 @@ document.addEventListener('DOMContentLoaded', function () {
                     if (!nodeCard) {
                         return;
                     }
-                    articleNode.hidden = !(activeTopic === 'all' || nodeCard.topic.toLowerCase() === activeTopic);
+                    var searchableText = [nodeCard.title, nodeCard.topic, nodeCard.excerpt].join(' ').toLowerCase();
+                    var matchesSearch = !searchTerm || searchableText.indexOf(searchTerm) !== -1;
+                    articleNode.hidden = !(activeArticleTopic === 'all' || nodeCard.topic.toLowerCase() === activeArticleTopic) || !matchesSearch;
                 });
             };
 
@@ -476,6 +490,12 @@ document.addEventListener('DOMContentLoaded', function () {
                         item.setAttribute('aria-pressed', isActive ? 'true' : 'false');
                     });
                     renderDiscoveryCards(activeTopic);
+                });
+            }
+
+            if (articleSearchInput) {
+                articleSearchInput.addEventListener('input', function () {
+                    renderDiscoveryCards(activeArticleTopic);
                 });
             }
         }


### PR DESCRIPTION
### Motivation
- Improve discoverability and make the articles page easy to scan and jump between full articles while keeping all existing content.  
- Provide fast search and topic filtering so every article card and the corresponding full article are easy to click and read.

### Description
- Updated `articles.html` to add an `articles-page` body class, refine the hero tagline, and insert a search input + discovery tools block to the top of the page.  
- Extended `js/main.js` to wire up `#articleSearchInput`, integrate keyword search into `renderDiscoveryCards`, surface excerpts and a "Read article" CTA on generated article cards, and keep full article sections in sync (hide/show) with active filters.  
- Appended page-specific styles to `css/style.css` under an `.articles-page` section to style the search/tools area, featured article layout, card grid, excerpt clamping, hover states, and mobile breakpoints.  
- Left all existing article content in place and preserved the table-of-contents panel while adding the new discovery UX and featured selection logic.

### Testing
- `node --check js/main.js` — succeeded.  
- HTML parse smoke test using `python3` HTMLParser on `articles.html` — succeeded.  
- `git diff --check` (style / whitespace checks) — succeeded.  
- Attempted automated screenshot with Playwright to visually verify the page, but the package download was blocked by the environment npm registry policy (403), so the screenshot step failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5408e7f4388326ad1d916cf88578a5)